### PR TITLE
fix(storybook): add all aliases to storybook

### DIFF
--- a/packages/constellation/.storybook/main.js
+++ b/packages/constellation/.storybook/main.js
@@ -1,4 +1,11 @@
+const createAlias = require("./utils/createAlias");
+
 module.exports = {
   stories: ['../src/**/*.stories.@(tsx|mdx)'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials', 'storybook-dark-mode'],
+  webpackFinal: (config) => {
+    config.resolve.alias = createAlias()
+    
+    return config;
+  }
 }

--- a/packages/constellation/.storybook/utils/createAlias.js
+++ b/packages/constellation/.storybook/utils/createAlias.js
@@ -1,0 +1,16 @@
+const path = require("path")
+const findAllDirectories = require("./findAllDirectories");
+
+const createAlias = () => {
+    const srcPath = path.resolve(__dirname, '..', '..', 'src');
+
+    const srcFolders = findAllDirectories(srcPath)
+
+    return srcFolders.reduce((alias, folderName) => {
+        alias[folderName] = path.resolve(srcPath, folderName);
+  
+        return alias;
+      }, {});
+}
+
+module.exports = createAlias

--- a/packages/constellation/.storybook/utils/findAllDirectories.js
+++ b/packages/constellation/.storybook/utils/findAllDirectories.js
@@ -1,0 +1,8 @@
+const { readdirSync } = require('fs')
+
+const findAllDirectories = (source) =>
+  readdirSync(source, { withFileTypes: true })
+    .filter(dirent => dirent.isDirectory())
+    .map(dirent => dirent.name)
+
+module.exports = findAllDirectories

--- a/packages/constellation/src/components/Icon/Icon.stories.tsx
+++ b/packages/constellation/src/components/Icon/Icon.stories.tsx
@@ -1,10 +1,8 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { colors } from 'colors'
+import Icon, { iconComponentMap, IconNameType } from 'components/Icon'
+import Text from 'components/Text'
 import React from 'react'
-
-import { colors } from '../../colors'
-import Text from '../Text'
-import Icon, { iconComponentMap } from '.'
-import { IconNameType } from './types'
 
 export default {
   argTypes: {

--- a/packages/constellation/src/components/Icon/index.tsx
+++ b/packages/constellation/src/components/Icon/index.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 
 import { theme } from '../../stitches.config'
 import { IconComponentProps, IconNameType } from './types'
-
 // icon imports
 import Activity from './icons/activity.svg'
 import Airdrop from './icons/airdrop.svg'
@@ -148,6 +147,8 @@ import VisibilityOff from './icons/visibilityOff.svg'
 import VisibilityOn from './icons/visibilityOn.svg'
 import Wallet from './icons/wallet.svg'
 import Withdraw from './icons/withdraw.svg'
+
+export type { IconNameType } from './types'
 
 // icon component map
 export const iconComponentMap: {


### PR DESCRIPTION
This adds all folders in the src file as alises
to storybook so storybook know how to resolve
imports like this "import Text from 'components/Text'"