### PR TITLE
fix(ThemeProvider): remove global css when adding font

### DIFF
--- a/packages/constellation/.storybook/preview-head.html
+++ b/packages/constellation/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+<link rel='stylesheet' type='text/css' href='https://rsms.me/inter/inter.css' />

--- a/packages/constellation/README.md
+++ b/packages/constellation/README.md
@@ -5,7 +5,8 @@ Base component library for React based applications built and used by [Blockchai
 ## Using the Library
 
 1. Install the library `yarn add @blockchain/constellation`
-2. Import and wrap your entire App with the ThemeProvider component. Example below
+2. Import Inter font. [see](/docs/fonts/index.md)
+3. Import and wrap your entire App with the ThemeProvider component. Example below
 
    ```js
     import { useEffect } from 'react'
@@ -35,7 +36,7 @@ Base component library for React based applications built and used by [Blockchai
     }
    ```
 
-3. That's it, happy hacking!
+4. That's it, happy hacking!
 
 ## Local Hacking Guide
 

--- a/packages/constellation/docs/fonts/index.md
+++ b/packages/constellation/docs/fonts/index.md
@@ -1,0 +1,3 @@
+# Fonts
+
+- [Inter](/docs/fonts/inter.md)

--- a/packages/constellation/docs/fonts/inter.md
+++ b/packages/constellation/docs/fonts/inter.md
@@ -1,0 +1,9 @@
+# Inter Font
+
+## Install
+
+CSS link
+
+```html
+<link rel="stylesheet" type="text/css" href="https://rsms.me/inter/inter.css" />
+```

--- a/packages/constellation/src/components/Text/index.tsx
+++ b/packages/constellation/src/components/Text/index.tsx
@@ -9,6 +9,7 @@ import { TextComponentProps } from './types'
 const BaseText = styled('span', {
   fontFeatureSettings: '"zero", "ss01"',
   color: '$grey800',
+  fontFamily: '$inter',
   variants: {
     color: Object.assign(
       {},

--- a/packages/constellation/src/providers/ThemeProvider/ThemeProvider.tsx
+++ b/packages/constellation/src/providers/ThemeProvider/ThemeProvider.tsx
@@ -6,26 +6,8 @@ import { ThemeProviderComponent } from './types'
 
 const normalizeStyles = globalCss(...normalize)
 
-/* eslint-disable sort-keys, sort-keys-fix/sort-keys-fix, import/no-unresolved */
-const fontStyles = globalCss({
-  '@import': "url('https://rsms.me/inter/inter.css')",
-  html: {
-    fontFamily:
-      "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif",
-  },
-  '@supports (font-variation-settings: normal)': {
-    html: {
-      fontFamily:
-        "'Inter var', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif",
-    },
-  },
-})
-/* eslint-enable sort-keys, sort-keys-fix/sort-keys-fix */
-
 const ThemeProvider: ThemeProviderComponent = ({ children, theme }) => {
   normalizeStyles()
-
-  fontStyles()
 
   return <div className={theme}>{children}</div>
 }


### PR DESCRIPTION
This removes the global css that is used to load the
default font. Now constellation will not add the Inter
font by itself
Instructions on how to add Inter font were added