### PR TITLE
fix(css): remove global css reset

### DIFF
--- a/packages/constellation/package.json
+++ b/packages/constellation/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@radix-ui/colors": "0.1.8",
-    "@radix-ui/react-accessible-icon": "^0.1.4",
+    "@radix-ui/react-accessible-icon": "0.1.4",
     "@radix-ui/react-avatar": "0.1.3",
     "@radix-ui/react-checkbox": "0.1.3",
     "@radix-ui/react-icons": "1.0.3",
@@ -116,8 +116,7 @@
     "@radix-ui/react-toggle": "0.1.3",
     "@radix-ui/react-toggle-group": "0.1.3",
     "@radix-ui/react-tooltip": "0.1.3",
-    "@stitches/react": "1.2.6",
-    "stitches-normalize-css": "1.2.0"
+    "@stitches/react": "1.2.6"
   },
   "lint-staged": {
     "src/**/*.{js,ts,tsx}": [

--- a/packages/constellation/src/providers/ThemeProvider/ThemeProvider.tsx
+++ b/packages/constellation/src/providers/ThemeProvider/ThemeProvider.tsx
@@ -1,15 +1,9 @@
 import React from 'react'
-import { normalize } from 'stitches-normalize-css'
 
-import { globalCss } from '../../stitches.config'
 import { ThemeProviderComponent } from './types'
 
-const normalizeStyles = globalCss(...normalize)
-
-const ThemeProvider: ThemeProviderComponent = ({ children, theme }) => {
-  normalizeStyles()
-
-  return <div className={theme}>{children}</div>
-}
+const ThemeProvider: ThemeProviderComponent = ({ children, theme }) => (
+  <div className={theme}>{children}</div>
+)
 
 export { ThemeProvider }

--- a/packages/constellation/src/stitches.config.ts
+++ b/packages/constellation/src/stitches.config.ts
@@ -3,80 +3,79 @@ import { createStitches } from '@stitches/react'
 
 import { colors } from './colors'
 
-const { config, createTheme, css, getCssText, globalCss, keyframes, styled, theme } =
-  createStitches({
-    media: {
-      dark: '(prefers-color-scheme: dark)',
-      hover: '(any-hover: hover)',
-      laptop: '(min-width: 1023px)',
-      light: '(prefers-color-scheme: light)',
-      mobile: '(min-width: 479px)',
-      motion: '(prefers-reduced-motion)',
-      tablet: '(min-width: 767px)',
+const { config, createTheme, css, getCssText, keyframes, styled, theme } = createStitches({
+  media: {
+    dark: '(prefers-color-scheme: dark)',
+    hover: '(any-hover: hover)',
+    laptop: '(min-width: 1023px)',
+    light: '(prefers-color-scheme: light)',
+    mobile: '(min-width: 479px)',
+    motion: '(prefers-reduced-motion)',
+    tablet: '(min-width: 767px)',
+  },
+  theme: {
+    colors: {
+      ...colors,
     },
-    theme: {
-      colors: {
-        ...colors,
-      },
-      fontSizes: {
-        10: '10px',
-        12: '12px',
-        14: '14px',
-        16: '16px',
-        20: '20px',
-        24: '24px',
-        32: '32px',
-        40: '40px',
-      },
-      fonts: {
-        inter:
-          "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif",
-      },
-      radii: {
-        1: '4px',
-        2: '8px',
-        3: '16px',
-        pill: '20%',
-        round: '50%',
-      },
-      sizes: {
-        16: '16px',
-        24: '24px',
-        32: '32px',
-        4: '4px',
-        40: '40px',
-        48: '48px',
-        64: '64px',
-        72: '64px',
-        8: '8px',
-        80: '80px',
-      },
-      space: {
-        120: '120px',
-        16: '16px',
-        24: '24px',
-        32: '32px',
-        4: '4px',
-        40: '40px',
-        48: '48px',
-        64: '64px',
-        8: '8px',
-        80: '80px',
-      },
-      zIndices: {
-        1: '100',
-        2: '200',
-        3: '300',
-        4: '400',
-        5: '500',
-        6: '600',
-        7: '700',
-        8: '800',
-        9: '900',
-        max: '9999',
-      },
+    fontSizes: {
+      10: '10px',
+      12: '12px',
+      14: '14px',
+      16: '16px',
+      20: '20px',
+      24: '24px',
+      32: '32px',
+      40: '40px',
     },
-  })
+    fonts: {
+      inter:
+        "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif",
+    },
+    radii: {
+      1: '4px',
+      2: '8px',
+      3: '16px',
+      pill: '20%',
+      round: '50%',
+    },
+    sizes: {
+      16: '16px',
+      24: '24px',
+      32: '32px',
+      4: '4px',
+      40: '40px',
+      48: '48px',
+      64: '64px',
+      72: '64px',
+      8: '8px',
+      80: '80px',
+    },
+    space: {
+      120: '120px',
+      16: '16px',
+      24: '24px',
+      32: '32px',
+      4: '4px',
+      40: '40px',
+      48: '48px',
+      64: '64px',
+      8: '8px',
+      80: '80px',
+    },
+    zIndices: {
+      1: '100',
+      2: '200',
+      3: '300',
+      4: '400',
+      5: '500',
+      6: '600',
+      7: '700',
+      8: '800',
+      9: '900',
+      max: '9999',
+    },
+  },
+})
 
 type ColorMode = 'light' | 'dark'
 
@@ -175,7 +174,6 @@ export {
   css,
   darkTheme,
   getCssText,
-  globalCss,
   keyframes,
   lightTheme,
   styled,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3451,7 +3451,7 @@ __metadata:
     "@babel/preset-react": 7.14.5
     "@babel/runtime": 7.16.7
     "@radix-ui/colors": 0.1.8
-    "@radix-ui/react-accessible-icon": ^0.1.4
+    "@radix-ui/react-accessible-icon": 0.1.4
     "@radix-ui/react-avatar": 0.1.3
     "@radix-ui/react-checkbox": 0.1.3
     "@radix-ui/react-icons": 1.0.3
@@ -3515,7 +3515,6 @@ __metadata:
     rollup-plugin-dts: 4.1.0
     rollup-plugin-peer-deps-external: 2.2.4
     rollup-plugin-terser: 7.0.2
-    stitches-normalize-css: 1.2.0
     storybook-dark-mode: 1.0.9
     stylelint: 13.12.0
     stylelint-config-constellation: "workspace:*"
@@ -4375,7 +4374,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-accessible-icon@npm:^0.1.4":
+"@radix-ui/react-accessible-icon@npm:0.1.4":
   version: 0.1.4
   resolution: "@radix-ui/react-accessible-icon@npm:0.1.4"
   dependencies:
@@ -19409,13 +19408,6 @@ fsevents@^1.2.7:
   version: 1.5.0
   resolution: "statuses@npm:1.5.0"
   checksum: c469b9519de16a4bb19600205cffb39ee471a5f17b82589757ca7bd40a8d92ebb6ed9f98b5a540c5d302ccbc78f15dc03cc0280dd6e00df1335568a5d5758a5c
-  languageName: node
-  linkType: hard
-
-"stitches-normalize-css@npm:1.2.0":
-  version: 1.2.0
-  resolution: "stitches-normalize-css@npm:1.2.0"
-  checksum: 8d8e53e89ca0d57f66750a08882ba4ce405057b27d4febe978ed5466488746938381795ce74612f5bd31db5051bb69f376e760aff6d367af283547188ed70235
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
using global css breaks apps such as the wallet that require a nonce to be added for all inline styles.  until Stitches supports that, we cannot set global styles :(