### PR TITLE
fix(@blockchain-com/icons): add common js to icons package

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -2,8 +2,13 @@
   "name": "@blockchain-com/icons",
   "version": "0.0.2",
   "packageManager": "yarn@3.1.1",
-  "module": "dist/index.esm.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "files": [
     "dist"
   ],

--- a/packages/icons/rollup.config.js
+++ b/packages/icons/rollup.config.js
@@ -8,10 +8,18 @@ const packageJson = require('./package.json')
 const config = [
   {
     input: 'src/index.ts',
-    output: {
-      file: packageJson.module,
-      format: 'esm',
-    },
+    output: [
+      {
+        file: packageJson.main,
+        format: 'cjs',
+        sourcemap: true,
+      },
+      {
+        file: packageJson.module,
+        format: 'esm',
+        sourcemap: true,
+      },
+    ],
     external: [/@babel\/runtime/, 'react'],
     plugins: [
       typescript({ tsconfig: './tsconfig.json' }),
@@ -20,7 +28,7 @@ const config = [
     ],
   },
   {
-    input: 'dist/types/index.d.ts',
+    input: 'dist/esm/types/index.d.ts',
     output: [{ file: 'dist/index.d.ts', format: 'esm' }],
     plugins: [dts()],
   },


### PR DESCRIPTION
Added the commonjs export so the other project can use the icons with jest to test components.
And jest cannot load esm modules, only commonjs