### PR TITLE
Add Button Component

### DIFF
--- a/packages/constellation/postcss.config.js
+++ b/packages/constellation/postcss.config.js
@@ -7,7 +7,9 @@ module.exports = {
     autoprefixer: {},
     'postcss-prefix-selector': {
       transform: (prefix, selector) => {
-        if (selector.startsWith('.constellation')) {
+        if (selector.includes('.mode-')) {
+          return selector.replace('.constellation ', '').replace(' .', ' .constellation .')
+        } else if (selector.startsWith('.constellation')) {
           return `${selector}, \n .constellation${selector.replace('.constellation ', '')}`
         }
 

--- a/packages/constellation/postcss.config.js
+++ b/packages/constellation/postcss.config.js
@@ -7,10 +7,12 @@ module.exports = {
     autoprefixer: {},
     'postcss-prefix-selector': {
       transform: (prefix, selector) => {
-        if (selector.includes('.mode-')) {
-          return selector.replace('.constellation ', '').replace(' .', ' .constellation .')
+        if (selector.startsWith('.constellation .mode-')) {
+          const selectorParts = selector.split(' ')
+
+          return `${selectorParts[1]} ${selectorParts[0]} ${selectorParts[2]},\n${selectorParts[1]} ${selectorParts[0]}${selectorParts[2]}`
         } else if (selector.startsWith('.constellation')) {
-          return `${selector}, \n .constellation${selector.replace('.constellation ', '')}`
+          return `${selector},\n.constellation${selector.replace('.constellation ', '')}`
         }
 
         return selector

--- a/packages/constellation/src/components/Base/Icon/Icon.stories.tsx
+++ b/packages/constellation/src/components/Base/Icon/Icon.stories.tsx
@@ -12,12 +12,12 @@ export const Icon = ({ icon = 'IconPlus', ...args }: Props & { icon: keyof typeo
 export const AllIcons = () => (
   <div className='constellation flex flex-wrap items-start gap-4'>
     {Object.keys(Icons).map((name) => {
-      const Component = Icons[name as keyof typeof Icons] as React.ComponentType
+      const Component = Icons[name as keyof typeof Icons]
 
       return (
         <div className='flex items-center gap-1 w-40' key={name}>
-          <Component />
-          <p className='text-xs'>{name}</p>
+          <Component color='var(--color-primary)' />
+          <p className='text-xs text-body'>{name}</p>
         </div>
       )
     })}
@@ -28,7 +28,9 @@ export default {
   argTypes: {
     color: {
       control: { type: 'select' },
-      options: ['#999999'], // TODO: update with colors enum,
+      // TODO: update with colors enum,
+      defaultValue: 'var(--color-primary)',
+      options: ['#999999', 'var(--color-primary)'],
     },
     icon: {
       control: { type: 'select' },

--- a/packages/constellation/src/components/Base/Icon/Icon.stories.tsx
+++ b/packages/constellation/src/components/Base/Icon/Icon.stories.tsx
@@ -16,6 +16,7 @@ export const AllIcons = () => (
 
       return (
         <div className='flex items-center gap-1 w-40' key={name}>
+          {/* TODO: update with colors enum */}
           <Component color='var(--color-primary)' />
           <p className='text-xs text-body'>{name}</p>
         </div>
@@ -28,7 +29,7 @@ export default {
   argTypes: {
     color: {
       control: { type: 'select' },
-      // TODO: update with colors enum,
+      // TODO: update with colors enum
       defaultValue: 'var(--color-primary)',
       options: ['#999999', 'var(--color-primary)'],
     },

--- a/packages/constellation/src/components/Base/Loaders/SpinningLoader/SpinningLoader.stories.tsx
+++ b/packages/constellation/src/components/Base/Loaders/SpinningLoader/SpinningLoader.stories.tsx
@@ -1,4 +1,5 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react'
+import cx from 'classnames'
 import React from 'react'
 
 import { SpinningLoader, SpinningLoaderComponent } from '.'
@@ -7,14 +8,17 @@ export default {
   argTypes: {
     borderWidth: {
       control: { type: 'radio' },
+      defaultValue: 'default',
       options: ['default', 'large', 'small', 'xsmall'],
     },
     size: {
       control: { type: 'radio' },
+      defaultValue: 'default',
       options: ['default', 'full', 'large', 'small'],
     },
     variant: {
       control: { type: 'radio' },
+      defaultValue: 'color',
       options: ['monotone', 'color'],
     },
   },
@@ -24,7 +28,11 @@ export default {
 
 const Template: ComponentStory<SpinningLoaderComponent> = ({ borderWidth, size, variant }) => {
   return (
-    <div className='constellation bg-body w-72 h-72 p-4 grid place-items-center'>
+    <div
+      className={cx('constellation w-72 h-72 p-4 grid place-items-center', {
+        'bg-grey-800 mode-dark:bg-dark-900': variant === 'monotone',
+      })}
+    >
       <SpinningLoader variant={variant} size={size} borderWidth={borderWidth} />
     </div>
   )

--- a/packages/constellation/src/components/Base/Loaders/SpinningLoader/SpinningLoader.stories.tsx
+++ b/packages/constellation/src/components/Base/Loaders/SpinningLoader/SpinningLoader.stories.tsx
@@ -7,7 +7,7 @@ export default {
   argTypes: {
     borderWidth: {
       control: { type: 'radio' },
-      options: ['default', 'large', 'small'],
+      options: ['default', 'large', 'small', 'xsmall'],
     },
     size: {
       control: { type: 'radio' },

--- a/packages/constellation/src/components/Base/Loaders/SpinningLoader/SpinningLoader.tsx
+++ b/packages/constellation/src/components/Base/Loaders/SpinningLoader/SpinningLoader.tsx
@@ -15,7 +15,7 @@ const variantClasses: Record<SpinningLoaderVariants, string> = {
 
 const sizeClasses: Record<SpinningLoaderSizes, string> = {
   default: 'h-16 w-16',
-  full: 'h-full w-full',
+  full: 'h-full w-full aspect-square',
   large: 'h-32 w-32',
   small: 'h-6 w-6',
 }
@@ -24,6 +24,7 @@ const borderWidthClasses: Record<SpinningLoaderWidths, string> = {
   default: 'border-8',
   large: 'border-[12px]',
   small: 'border-4',
+  xsmall: 'border-[3px]',
 }
 
 const SpinningLoader: SpinningLoaderComponent = ({

--- a/packages/constellation/src/components/Base/Loaders/SpinningLoader/SpinningLoader.types.ts
+++ b/packages/constellation/src/components/Base/Loaders/SpinningLoader/SpinningLoader.types.ts
@@ -2,7 +2,7 @@ import { FC } from 'react'
 
 export type SpinningLoaderVariants = 'monotone' | 'color'
 export type SpinningLoaderSizes = 'default' | 'full' | 'large' | 'small'
-export type SpinningLoaderWidths = 'default' | 'large' | 'small'
+export type SpinningLoaderWidths = 'default' | 'large' | 'small' | 'xsmall'
 
 export interface SpinningLoaderProps {
   borderWidth?: SpinningLoaderWidths

--- a/packages/constellation/src/components/Compositions/Button/Button.stories.tsx
+++ b/packages/constellation/src/components/Compositions/Button/Button.stories.tsx
@@ -38,7 +38,7 @@ export default {
   title: 'Primitives/Buttons',
 } as ComponentMeta<Component>
 
-const Template: ComponentStory<Component> = ({ children = 'Large', size = 'default', ...args }) => {
+const Template: ComponentStory<Component> = ({ size = 'default', ...args }) => {
   return (
     <ButtonComponent size={size} {...args}>{`${size[0].toUpperCase()}${size.slice(
       1,

--- a/packages/constellation/src/components/Compositions/Button/Button.stories.tsx
+++ b/packages/constellation/src/components/Compositions/Button/Button.stories.tsx
@@ -1,7 +1,7 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import React from 'react'
 
-import { IconActivity } from '../../Base'
+import { IconApple } from '../../Base'
 import { Button as ButtonComponent, Component } from '.'
 
 export default {
@@ -9,9 +9,15 @@ export default {
     as: {
       control: { type: 'select' },
       defaultValue: 'button',
+      description: 'Allows for overriding the underlying DOM element ',
       options: ['button', 'div', 'a'],
     },
     disabled: { control: { type: 'boolean' }, defaultValue: false },
+    icon: {
+      control: { type: 'boolean' },
+      defaultValue: true,
+      description: 'An optional Icon displayed inline with button text',
+    },
     onClick: { action: 'click' },
     size: {
       control: { type: 'radio' },
@@ -21,9 +27,10 @@ export default {
     state: {
       control: { type: 'radio' },
       defaultValue: 'initial',
+      description: 'An optional visual progress indication of a tiggered button action',
       options: ['initial', 'loading', 'success'],
     },
-    text: { control: { type: 'text' } },
+    text: { control: { type: 'text' }, description: 'Text content of button' },
     type: {
       control: { type: 'select' },
       defaultValue: 'button',
@@ -32,6 +39,7 @@ export default {
     variant: {
       control: { type: 'radio' },
       defaultValue: 'primary',
+      description: 'The stylistic variant to use when rendering.',
       options: ['primary', 'secondary', 'minimal'],
     },
     width: {
@@ -44,13 +52,13 @@ export default {
   title: 'Primitives/Buttons',
 } as ComponentMeta<Component>
 
-const Template: ComponentStory<Component> = ({ size = 'default', ...args }) => {
+const Template: ComponentStory<Component> = ({ icon, size = 'default', text, ...args }) => {
   return (
     <ButtonComponent
       {...args}
       size={size}
-      icon={<IconActivity />}
-      text={`${size[0].toUpperCase()}${size.slice(1)}`}
+      icon={icon && <IconApple />}
+      text={text || `${size[0].toUpperCase()}${size.slice(1)}`}
     />
   )
 }

--- a/packages/constellation/src/components/Compositions/Button/Button.stories.tsx
+++ b/packages/constellation/src/components/Compositions/Button/Button.stories.tsx
@@ -7,25 +7,30 @@ export default {
   argTypes: {
     as: {
       control: { type: 'select' },
+      defaultValue: 'button',
       options: ['button', 'div', 'a'],
     },
     children: { control: { type: 'text' } },
-    disabled: { control: { type: 'boolean' } },
+    disabled: { control: { type: 'boolean' }, defaultValue: false },
     onClick: { action: 'click' },
     size: {
       control: { type: 'radio' },
+      defaultValue: 'large',
       options: ['default', 'large', 'small'],
     },
     state: {
       control: { type: 'radio' },
+      defaultValue: 'initial',
       options: ['initial', 'loading', 'success'],
     },
     type: {
       control: { type: 'select' },
+      defaultValue: 'button',
       options: ['button', 'reset', 'submit'],
     },
     variant: {
       control: { type: 'radio' },
+      defaultValue: 'primary',
       options: ['primary', 'secondary', 'minimal'],
     },
   },

--- a/packages/constellation/src/components/Compositions/Button/Button.stories.tsx
+++ b/packages/constellation/src/components/Compositions/Button/Button.stories.tsx
@@ -1,0 +1,40 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import React from 'react'
+
+import { Button as ButtonComponent, Component } from '.'
+
+export default {
+  argTypes: {
+    as: {
+      control: { type: 'select' },
+      options: ['button', 'div', 'a'],
+    },
+    children: { control: { type: 'text' } },
+    disabled: { control: { type: 'boolean' } },
+    onClick: { action: 'click' },
+    size: {
+      control: { type: 'radio' },
+      options: ['default', 'large', 'small'],
+    },
+    type: {
+      control: { type: 'select' },
+      options: ['button', 'reset', 'submit'],
+    },
+    variant: {
+      control: { type: 'radio' },
+      options: ['primary', 'secondary', 'minimal'],
+    },
+    width: {
+      control: { type: 'select' },
+      options: ['none', 'flex', 'percent'],
+    },
+  },
+  component: ButtonComponent,
+  title: 'Primitives/Buttons',
+} as ComponentMeta<Component>
+
+const Template: ComponentStory<Component> = ({ children = 'Large', ...args }) => {
+  return <ButtonComponent {...args}>{children}</ButtonComponent>
+}
+
+export const Button = Template.bind({})

--- a/packages/constellation/src/components/Compositions/Button/Button.stories.tsx
+++ b/packages/constellation/src/components/Compositions/Button/Button.stories.tsx
@@ -16,6 +16,10 @@ export default {
       control: { type: 'radio' },
       options: ['default', 'large', 'small'],
     },
+    state: {
+      control: { type: 'radio' },
+      options: ['initial', 'loading', 'success'],
+    },
     type: {
       control: { type: 'select' },
       options: ['button', 'reset', 'submit'],
@@ -24,17 +28,17 @@ export default {
       control: { type: 'radio' },
       options: ['primary', 'secondary', 'minimal'],
     },
-    width: {
-      control: { type: 'select' },
-      options: ['none', 'flex', 'percent'],
-    },
   },
   component: ButtonComponent,
   title: 'Primitives/Buttons',
 } as ComponentMeta<Component>
 
-const Template: ComponentStory<Component> = ({ children = 'Large', ...args }) => {
-  return <ButtonComponent {...args}>{children}</ButtonComponent>
+const Template: ComponentStory<Component> = ({ children = 'Large', size = 'default', ...args }) => {
+  return (
+    <ButtonComponent size={size} {...args}>{`${size[0].toUpperCase()}${size.slice(
+      1,
+    )}`}</ButtonComponent>
+  )
 }
 
 export const Button = Template.bind({})

--- a/packages/constellation/src/components/Compositions/Button/Button.stories.tsx
+++ b/packages/constellation/src/components/Compositions/Button/Button.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import React from 'react'
 
+import { IconActivity } from '../../Base'
 import { Button as ButtonComponent, Component } from '.'
 
 export default {
@@ -10,7 +11,6 @@ export default {
       defaultValue: 'button',
       options: ['button', 'div', 'a'],
     },
-    children: { control: { type: 'text' } },
     disabled: { control: { type: 'boolean' }, defaultValue: false },
     onClick: { action: 'click' },
     size: {
@@ -23,6 +23,7 @@ export default {
       defaultValue: 'initial',
       options: ['initial', 'loading', 'success'],
     },
+    text: { control: { type: 'text' } },
     type: {
       control: { type: 'select' },
       defaultValue: 'button',
@@ -33,6 +34,11 @@ export default {
       defaultValue: 'primary',
       options: ['primary', 'secondary', 'minimal'],
     },
+    width: {
+      control: { type: 'radio' },
+      defaultValue: 'auto',
+      options: ['auto', 'full'],
+    },
   },
   component: ButtonComponent,
   title: 'Primitives/Buttons',
@@ -40,9 +46,12 @@ export default {
 
 const Template: ComponentStory<Component> = ({ size = 'default', ...args }) => {
   return (
-    <ButtonComponent size={size} {...args}>{`${size[0].toUpperCase()}${size.slice(
-      1,
-    )}`}</ButtonComponent>
+    <ButtonComponent
+      {...args}
+      size={size}
+      icon={<IconActivity />}
+      text={`${size[0].toUpperCase()}${size.slice(1)}`}
+    />
   )
 }
 

--- a/packages/constellation/src/components/Compositions/Button/Button.tsx
+++ b/packages/constellation/src/components/Compositions/Button/Button.tsx
@@ -1,7 +1,14 @@
 import cx from 'classnames'
 import React, { forwardRef } from 'react'
 
-import { ButtonVariants, Component as ComponentType, Props, Sizes } from './Button.types'
+import { IconCheck, SpinningLoader } from '../../Base'
+import {
+  ButtonState,
+  ButtonVariants,
+  Component as ComponentType,
+  Props,
+  Sizes,
+} from './Button.types'
 
 /**
  * Buttons allow users to take actions, and make choices, with a single tap.
@@ -14,22 +21,49 @@ import { ButtonVariants, Component as ComponentType, Props, Sizes } from './Butt
 
 const variantStyles: Record<ButtonVariants, string> = {
   minimal:
-    'bg-background text-primary border border-grey-100 hover:dark:border-dark-500 hover:dark:bg-dark-800 hover:bg-blue-000 hover:border-blue-400 dark:border-dark-500 active:bg-blue-000 active:border-primary focus:bg-blue-000 focus:border-primary disabled:text-muted disabled:bg-background disabled:border-grey-100',
+    'bg-background text-primary dark:text-blue-300 border border-grey-100 dark:hover:border-dark-500 dark:hover:bg-dark-800 hover:bg-blue-000 hover:border-blue-400 dark:border-dark-500 active:bg-blue-000 active:border-primary focus:bg-blue-000 focus:border-primary disabled:text-muted disabled:bg-background disabled:border-grey-100',
   primary:
-    'bg-blue-600 hover:bg-blue-700 focus:bg-blue-800 active:bg-blue-900 text-white-000 disabled:bg-blue-400 disabled:text-overlay-light-600',
+    'text-white-000 bg-blue-600 hover:bg-blue-700 focus:bg-blue-800 active:bg-blue-900  disabled:bg-blue-300 disabled:text-overlay-light-600',
   secondary:
-    'bg-grey-800 hover:bg-grey-700 focus:bg-grey-900 active:bg-grey-900 disabled:bg-grey-500 text-white-000 disabled:text-overlay-light-600',
+    'text-white-000 bg-grey-800 hover:bg-grey-700 focus:bg-grey-900 active:bg-grey-900 disabled:bg-grey-500  disabled:text-overlay-light-600',
 }
 
 const sizeStyles: Record<Sizes, string> = {
-  default: 'px-6 py-3 text-base',
-  large: 'px-10 py-4 text-xl',
-  small: 'px-3 py-1.5 text-sm',
+  default: 'px-6 py-3 text-base h-12',
+  large: 'px-10 py-4 text-xl h-16',
+  small: 'px-3 py-1.5 text-sm h-8',
+}
+
+const stateStyles: Record<ButtonState, Record<Sizes, string>> = {
+  initial: {
+    default: '',
+    large: '',
+    small: '',
+  },
+  loading: {
+    default: 'px-14 py-3',
+    large: 'px-16 py-5',
+    small: 'px-8 py-2',
+  },
+  success: {
+    default: 'px-14 py-3',
+    large: 'px-16 py-5',
+    small: 'px-8 py-2',
+  },
 }
 
 const Button: ComponentType = forwardRef(
   <T extends React.ElementType = 'button'>(
-    { as, disabled = false, size = 'default', type, variant = 'primary', ...otherProps }: Props<T>,
+    {
+      as,
+      children,
+      disabled = false,
+      size = 'default',
+      state = 'initial',
+      type,
+      variant = 'primary',
+      ...otherProps
+    }: Props<T>,
     ref?: PolymorphicRef<T>,
   ) => {
     const Component = as || 'button'
@@ -37,12 +71,27 @@ const Button: ComponentType = forwardRef(
 
     return (
       <Component
-        className={cx(variantStyles[variant], sizeStyles[size], 'rounded-lg font-semibold')}
+        className={cx(
+          variantStyles[variant],
+          sizeStyles[size],
+          stateStyles[state][size],
+          'rounded-lg font-semibold box-border',
+        )}
         ref={ref}
         type={type || fallbackType}
         disabled={disabled}
         {...otherProps}
-      />
+      >
+        {state === 'initial' && children}
+        {state === 'loading' && (
+          <SpinningLoader
+            size='full'
+            borderWidth={size === 'small' ? 'xsmall' : 'small'}
+            variant={variant === 'minimal' ? 'color' : 'monotone'}
+          />
+        )}
+        {state === 'success' && <IconCheck />}
+      </Component>
     )
   },
 )

--- a/packages/constellation/src/components/Compositions/Button/Button.tsx
+++ b/packages/constellation/src/components/Compositions/Button/Button.tsx
@@ -21,11 +21,11 @@ import {
 
 const variantStyles: Record<ButtonVariants, string> = {
   minimal:
-    'bg-background mode-dark:bg-dark-900 text-primary mode-dark:text-blue-300 border border-grey-100 active:bg-blue-000 active:border-primary focus:bg-blue-000 focus:border-primary disabled:text-muted disabled:bg-background disabled:border-grey-100 hover:bg-blue-000 hover:border-blue-400 mode-dark:hover:border-dark-400 mode-dark:hover:bg-dark-800 mode-dark:border-dark-500 mode-dark:active:bg-dark-700 mode-dark:active:border-blue-400 mode-dark:focus:bg-dark-700 mode-dark:focus:border-blue-400  mode-dark:disabled:text-grey-600 mode-dark:disabled:bg-background mode-dark:disabled:border-grey-700',
+    'bg-white-000 mode-dark:bg-dark-900 text-blue-600 mode-dark:text-blue-300 border border-grey-100 active:bg-blue-000 active:border-primary focus:bg-blue-000 focus:border-primary disabled:text-muted disabled:bg-background disabled:border-grey-100 hover:bg-blue-000 hover:border-blue-400 mode-dark:hover:border-dark-400 mode-dark:hover:bg-dark-800 mode-dark:border-dark-500 mode-dark:active:bg-dark-700 mode-dark:active:border-blue-400 mode-dark:focus:bg-dark-700 mode-dark:focus:border-blue-400 mode-dark:disabled:text-grey-600 mode-dark:disabled:bg-background mode-dark:disabled:border-grey-700',
   primary:
-    'text-white-000 bg-blue-600 hover:bg-blue-700 focus:bg-blue-800 active:bg-blue-900  disabled:bg-blue-300 disabled:text-overlay-light-600',
+    'text-white-000 bg-blue-600 border border-transparent mode-dark:border-transparent hover:bg-blue-700 focus:bg-blue-800 active:bg-blue-900 disabled:bg-blue-300 disabled:text-overlay-light-600',
   secondary:
-    'text-white-000 bg-grey-800 hover:bg-grey-700 focus:bg-grey-900 active:bg-grey-900 disabled:bg-grey-500  disabled:text-overlay-light-600',
+    'text-white-000 bg-grey-800 border border-transparent mode-dark:border-transparent hover:bg-grey-700 focus:bg-grey-900 active:bg-grey-900 disabled:bg-grey-500 disabled:text-overlay-light-600',
 }
 
 const sizeStyles: Record<Sizes, string> = {
@@ -56,12 +56,14 @@ const Button: ComponentType = forwardRef(
   <T extends React.ElementType = 'button'>(
     {
       as,
-      children,
       disabled = false,
+      icon,
       size = 'default',
       state = 'initial',
+      text,
       type,
       variant = 'primary',
+      width = 'auto',
       ...otherProps
     }: Props<T>,
     ref?: PolymorphicRef<T>,
@@ -72,17 +74,25 @@ const Button: ComponentType = forwardRef(
     return (
       <Component
         className={cx(
+          'constellation rounded-lg font-semibold cursor-pointer disabled:cursor-not-allowed transition-all flex items-center gap-2',
           variantStyles[variant],
           sizeStyles[size],
           stateStyles[state][size],
-          'constellation rounded-lg font-semibold box-border cursor-pointer disabled:cursor-default transition-all',
+          {
+            'w-full justify-center': width === 'full',
+          },
         )}
         ref={ref}
         type={type || fallbackType}
         disabled={disabled}
         {...otherProps}
       >
-        {state === 'initial' && children}
+        {state === 'initial' && (
+          <>
+            {icon && icon}
+            {text}
+          </>
+        )}
         {state === 'loading' && (
           <SpinningLoader
             size='full'

--- a/packages/constellation/src/components/Compositions/Button/Button.tsx
+++ b/packages/constellation/src/components/Compositions/Button/Button.tsx
@@ -21,7 +21,7 @@ import {
 
 const variantStyles: Record<ButtonVariants, string> = {
   minimal:
-    'bg-background mode-dark:bg-dark-900 text-primary mode-dark:text-blue-300 border border-grey-100 active:bg-blue-000 active:border-primary focus:bg-blue-000 focus:border-primary disabled:text-muted disabled:bg-background disabled:border-grey-100 mode-dark:hover:border-dark-400 mode-dark:hover:bg-dark-800 hover:bg-blue-000 hover:border-blue-400 mode-dark:border-dark-500 mode-dark:active:bg-dark-700 mode-dark:active:border-blue-400 mode-dark:focus:bg-dark-700 mode-dark:focus:border-blue-400  mode-dark:disabled:text-grey-600 mode-dark:disabled:bg-background mode-dark:disabled:border-grey-700',
+    'bg-background mode-dark:bg-dark-900 text-primary mode-dark:text-blue-300 border border-grey-100 active:bg-blue-000 active:border-primary focus:bg-blue-000 focus:border-primary disabled:text-muted disabled:bg-background disabled:border-grey-100 hover:bg-blue-000 hover:border-blue-400 mode-dark:hover:border-dark-400 mode-dark:hover:bg-dark-800 mode-dark:border-dark-500 mode-dark:active:bg-dark-700 mode-dark:active:border-blue-400 mode-dark:focus:bg-dark-700 mode-dark:focus:border-blue-400  mode-dark:disabled:text-grey-600 mode-dark:disabled:bg-background mode-dark:disabled:border-grey-700',
   primary:
     'text-white-000 bg-blue-600 hover:bg-blue-700 focus:bg-blue-800 active:bg-blue-900  disabled:bg-blue-300 disabled:text-overlay-light-600',
   secondary:

--- a/packages/constellation/src/components/Compositions/Button/Button.tsx
+++ b/packages/constellation/src/components/Compositions/Button/Button.tsx
@@ -74,12 +74,13 @@ const Button: ComponentType = forwardRef(
     return (
       <Component
         className={cx(
-          'constellation rounded-lg font-semibold cursor-pointer disabled:cursor-not-allowed transition-all flex items-center gap-2',
+          'constellation rounded-lg font-semibold cursor-pointer disabled:cursor-not-allowed transition-all flex items-center justify-center gap-2',
           variantStyles[variant],
           sizeStyles[size],
           stateStyles[state][size],
           {
-            'w-full justify-center': width === 'full',
+            'w-fit': width === 'auto',
+            'w-full': width === 'full',
           },
         )}
         ref={ref}

--- a/packages/constellation/src/components/Compositions/Button/Button.tsx
+++ b/packages/constellation/src/components/Compositions/Button/Button.tsx
@@ -21,7 +21,7 @@ import {
 
 const variantStyles: Record<ButtonVariants, string> = {
   minimal:
-    'bg-background text-primary mode-dark:text-blue-300 border border-grey-100 active:bg-blue-000 active:border-primary focus:bg-blue-000 focus:border-primary disabled:text-muted disabled:bg-background disabled:border-grey-100 mode-dark:hover:border-dark-400 mode-dark:hover:bg-dark-800 hover:bg-blue-000 hover:border-blue-400 mode-dark:border-dark-500 mode-dark:active:bg-dark-700 mode-dark:active:border-blue-400 mode-dark:focus:bg-dark-700 mode-dark:focus:border-blue-400  mode-dark:disabled:text-grey-600 mode-dark:disabled:bg-background mode-dark:disabled:border-grey-700',
+    'bg-background mode-dark:bg-dark-900 text-primary mode-dark:text-blue-300 border border-grey-100 active:bg-blue-000 active:border-primary focus:bg-blue-000 focus:border-primary disabled:text-muted disabled:bg-background disabled:border-grey-100 mode-dark:hover:border-dark-400 mode-dark:hover:bg-dark-800 hover:bg-blue-000 hover:border-blue-400 mode-dark:border-dark-500 mode-dark:active:bg-dark-700 mode-dark:active:border-blue-400 mode-dark:focus:bg-dark-700 mode-dark:focus:border-blue-400  mode-dark:disabled:text-grey-600 mode-dark:disabled:bg-background mode-dark:disabled:border-grey-700',
   primary:
     'text-white-000 bg-blue-600 hover:bg-blue-700 focus:bg-blue-800 active:bg-blue-900  disabled:bg-blue-300 disabled:text-overlay-light-600',
   secondary:
@@ -75,7 +75,7 @@ const Button: ComponentType = forwardRef(
           variantStyles[variant],
           sizeStyles[size],
           stateStyles[state][size],
-          'constellation rounded-lg font-semibold box-border',
+          'constellation rounded-lg font-semibold box-border cursor-pointer disabled:cursor-default transition-all',
         )}
         ref={ref}
         type={type || fallbackType}

--- a/packages/constellation/src/components/Compositions/Button/Button.tsx
+++ b/packages/constellation/src/components/Compositions/Button/Button.tsx
@@ -21,7 +21,7 @@ import {
 
 const variantStyles: Record<ButtonVariants, string> = {
   minimal:
-    'bg-background text-primary theme-dark:text-blue-300 border border-grey-100 active:bg-blue-000 active:border-primary focus:bg-blue-000 focus:border-primary disabled:text-muted disabled:bg-background disabled:border-grey-100 theme-dark:hover:border-dark-400 theme-dark:hover:bg-dark-800 hover:bg-blue-000 hover:border-blue-400 theme-dark:border-dark-500 theme-dark:active:bg-dark-700 theme-dark:active:border-blue-400 theme-dark:focus:bg-dark-700 theme-dark:focus:border-blue-400  theme-dark:disabled:text-grey-600 theme-dark:disabled:bg-background theme-dark:disabled:border-grey-700',
+    'bg-background text-primary mode-dark:text-blue-300 border border-grey-100 active:bg-blue-000 active:border-primary focus:bg-blue-000 focus:border-primary disabled:text-muted disabled:bg-background disabled:border-grey-100 mode-dark:hover:border-dark-400 mode-dark:hover:bg-dark-800 hover:bg-blue-000 hover:border-blue-400 mode-dark:border-dark-500 mode-dark:active:bg-dark-700 mode-dark:active:border-blue-400 mode-dark:focus:bg-dark-700 mode-dark:focus:border-blue-400  mode-dark:disabled:text-grey-600 mode-dark:disabled:bg-background mode-dark:disabled:border-grey-700',
   primary:
     'text-white-000 bg-blue-600 hover:bg-blue-700 focus:bg-blue-800 active:bg-blue-900  disabled:bg-blue-300 disabled:text-overlay-light-600',
   secondary:

--- a/packages/constellation/src/components/Compositions/Button/Button.tsx
+++ b/packages/constellation/src/components/Compositions/Button/Button.tsx
@@ -21,7 +21,7 @@ import {
 
 const variantStyles: Record<ButtonVariants, string> = {
   minimal:
-    'bg-background text-primary dark:text-blue-300 border border-grey-100 dark:hover:border-dark-500 dark:hover:bg-dark-800 hover:bg-blue-000 hover:border-blue-400 dark:border-dark-500 active:bg-blue-000 active:border-primary focus:bg-blue-000 focus:border-primary disabled:text-muted disabled:bg-background disabled:border-grey-100',
+    'bg-background text-primary theme-dark:text-blue-300 border border-grey-100 active:bg-blue-000 active:border-primary focus:bg-blue-000 focus:border-primary disabled:text-muted disabled:bg-background disabled:border-grey-100 theme-dark:hover:border-dark-400 theme-dark:hover:bg-dark-800 hover:bg-blue-000 hover:border-blue-400 theme-dark:border-dark-500 theme-dark:active:bg-dark-700 theme-dark:active:border-blue-400 theme-dark:focus:bg-dark-700 theme-dark:focus:border-blue-400  theme-dark:disabled:text-grey-600 theme-dark:disabled:bg-background theme-dark:disabled:border-grey-700',
   primary:
     'text-white-000 bg-blue-600 hover:bg-blue-700 focus:bg-blue-800 active:bg-blue-900  disabled:bg-blue-300 disabled:text-overlay-light-600',
   secondary:

--- a/packages/constellation/src/components/Compositions/Button/Button.tsx
+++ b/packages/constellation/src/components/Compositions/Button/Button.tsx
@@ -75,7 +75,7 @@ const Button: ComponentType = forwardRef(
           variantStyles[variant],
           sizeStyles[size],
           stateStyles[state][size],
-          'rounded-lg font-semibold box-border',
+          'constellation rounded-lg font-semibold box-border',
         )}
         ref={ref}
         type={type || fallbackType}

--- a/packages/constellation/src/components/Compositions/Button/Button.tsx
+++ b/packages/constellation/src/components/Compositions/Button/Button.tsx
@@ -1,0 +1,50 @@
+import cx from 'classnames'
+import React, { forwardRef } from 'react'
+
+import { ButtonVariants, Component as ComponentType, Props, Sizes } from './Button.types'
+
+/**
+ * Buttons allow users to take actions, and make choices, with a single tap.
+ *
+ * When a `ref` prop is provided, it will be forwarded to the root element. Any
+ * other properties supplied will be provided to the root element (ie, the `as`
+ * prop value). This includes all appropriate HTML attributes or aria tags. This
+ * component may have its underlying DOM customized via the 'as' prop.
+ */
+
+const variantStyles: Record<ButtonVariants, string> = {
+  minimal:
+    'bg-background text-primary border border-grey-100 hover:dark:border-dark-500 hover:dark:bg-dark-800 hover:bg-blue-000 hover:border-blue-400 dark:border-dark-500 active:bg-blue-000 active:border-primary focus:bg-blue-000 focus:border-primary disabled:text-muted disabled:bg-background disabled:border-grey-100',
+  primary:
+    'bg-blue-600 hover:bg-blue-700 focus:bg-blue-800 active:bg-blue-900 text-white-000 disabled:bg-blue-400 disabled:text-overlay-light-600',
+  secondary:
+    'bg-grey-800 hover:bg-grey-700 focus:bg-grey-900 active:bg-grey-900 disabled:bg-grey-500 text-white-000 disabled:text-overlay-light-600',
+}
+
+const sizeStyles: Record<Sizes, string> = {
+  default: 'px-6 py-3 text-base',
+  large: 'px-10 py-4 text-xl',
+  small: 'px-3 py-1.5 text-sm',
+}
+
+const Button: ComponentType = forwardRef(
+  <T extends React.ElementType = 'button'>(
+    { as, disabled = false, size = 'default', type, variant = 'primary', ...otherProps }: Props<T>,
+    ref?: PolymorphicRef<T>,
+  ) => {
+    const Component = as || 'button'
+    const fallbackType = Component === 'button' && !type ? 'button' : undefined
+
+    return (
+      <Component
+        className={cx(variantStyles[variant], sizeStyles[size], 'rounded-lg font-semibold')}
+        ref={ref}
+        type={type || fallbackType}
+        disabled={disabled}
+        {...otherProps}
+      />
+    )
+  },
+)
+
+export default Button

--- a/packages/constellation/src/components/Compositions/Button/Button.types.ts
+++ b/packages/constellation/src/components/Compositions/Button/Button.types.ts
@@ -1,11 +1,17 @@
+import React from 'react'
+
 export type ButtonVariants = 'primary' | 'secondary' | 'minimal'
-export type ButtonWidths = 'flex' | 'percent'
+export type ButtonWidths = 'auto' | 'full'
 export type Sizes = 'default' | 'large' | 'small'
 export type ButtonState = 'initial' | 'loading' | 'success'
 
 export type Props<T extends React.ElementType> = PolymorphicComponentPropsWithRef<
   T,
   {
+    /**
+     * An optional Icon displayed inline with button text
+     */
+    icon?: React.ReactNode
     /**
      * The size of the button, from a range of variants.
      */
@@ -14,6 +20,10 @@ export type Props<T extends React.ElementType> = PolymorphicComponentPropsWithRe
      * An optional visual progress indication of a tiggered button action
      */
     state?: ButtonState
+    /**
+     * Text content of button
+     */
+    text: string
     /**
      * The stylistic variant to use when rendering.
      *

--- a/packages/constellation/src/components/Compositions/Button/Button.types.ts
+++ b/packages/constellation/src/components/Compositions/Button/Button.types.ts
@@ -1,7 +1,7 @@
 export type ButtonVariants = 'primary' | 'secondary' | 'minimal'
 export type ButtonWidths = 'flex' | 'percent'
 export type Sizes = 'default' | 'large' | 'small'
-export type ButtonState = 'default' | 'loading' | 'success'
+export type ButtonState = 'initial' | 'loading' | 'success'
 
 export type Props<T extends React.ElementType> = PolymorphicComponentPropsWithRef<
   T,

--- a/packages/constellation/src/components/Compositions/Button/Button.types.ts
+++ b/packages/constellation/src/components/Compositions/Button/Button.types.ts
@@ -1,0 +1,34 @@
+export type ButtonVariants = 'primary' | 'secondary' | 'minimal'
+export type ButtonWidths = 'flex' | 'percent'
+export type Sizes = 'default' | 'large' | 'small'
+export type ButtonState = 'default' | 'loading' | 'success'
+
+export type Props<T extends React.ElementType> = PolymorphicComponentPropsWithRef<
+  T,
+  {
+    /**
+     * The size of the button, from a range of variants.
+     */
+    size?: Sizes
+    /**
+     * An optional visual progress indication of a tiggered button action
+     */
+    state?: ButtonState
+    /**
+     * The stylistic variant to use when rendering.
+     *
+     * @default "primary"
+     */
+    variant?: ButtonVariants
+    /**
+     * Normally, buttons are only as wide as needed to contain their content.
+     * This prop will let you set the button to fill with width of it's parent
+     * element, either via flex or width percentage.
+     */
+    width?: ButtonWidths
+  }
+>
+
+export type Component = <T extends React.ElementType = 'button'>(
+  props: Props<T>,
+) => React.ReactElement | null

--- a/packages/constellation/src/components/Compositions/Button/Button.types.ts
+++ b/packages/constellation/src/components/Compositions/Button/Button.types.ts
@@ -26,8 +26,6 @@ export type Props<T extends React.ElementType> = PolymorphicComponentPropsWithRe
     text: string
     /**
      * The stylistic variant to use when rendering.
-     *
-     * @default "primary"
      */
     variant?: ButtonVariants
     /**

--- a/packages/constellation/src/components/Compositions/Button/index.ts
+++ b/packages/constellation/src/components/Compositions/Button/index.ts
@@ -1,0 +1,2 @@
+export { default as Button } from './Button'
+export type { Component, Props } from './Button.types'

--- a/packages/constellation/src/components/Compositions/index.ts
+++ b/packages/constellation/src/components/Compositions/index.ts
@@ -1,1 +1,2 @@
+export * from './Button'
 export * from './Slider'

--- a/packages/constellation/src/global.d.ts
+++ b/packages/constellation/src/global.d.ts
@@ -1,0 +1,27 @@
+// The 'as' prop is intended to allow the user to configure the HTML tag the
+// component renders with. It can also be another React component.
+type AsProp<T extends React.ElementType> = { as?: T }
+
+// Allows for inheriting the props from the specified element type, so that
+// props like `children`, `className` & `style` work, as well as element-
+// specific attributes like aria roles. The component (`T`) must be passed in.
+type ElementProps<T extends React.ElementType, Props = Record<string, unknown>> = Props &
+  Omit<React.ComponentPropsWithoutRef<T>, keyof Props>
+
+// Extract the `ref` prop type from a polymorphic component.
+type PolymorphicRef<T extends React.ElementType> = React.ComponentPropsWithRef<T>['ref']
+
+// Defines the prop types of a polymorphic component (IE, one that supports an
+// 'as' prop, which can be used to configure the rendered HTML tag of the
+// component.) The component, `T`, must be passed in.
+type PolymorphicComponentProps<T extends React.ElementType, Props = Record<string, unknown>> =
+  ElementProps<T, Props & AsProp<T>>
+
+// Defines the prop types of a polymorphic component (IE, one that supports an
+// 'as' prop, which can be used to configure the rendered HTML tag of the
+// component.) This is the same as `PolymorphicComponentProps`, except it also
+// supports the `ref` prop.
+type PolymorphicComponentPropsWithRef<
+  T extends React.ElementType,
+  Props = Record<string, unknown>,
+> = PolymorphicComponentProps<T, Props> & { ref?: PolymorphicRef<T> }

--- a/packages/constellation/src/input.css
+++ b/packages/constellation/src/input.css
@@ -3,6 +3,418 @@
 @tailwind utilities;
 
 @layer base {
+    /*
+    ! tailwindcss v3.1.4 | MIT License | https://tailwindcss.com
+    */
+
+    /*
+    1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
+    2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
+    */
+
+    * .constellation,
+    .constellation::before,
+    .constellation::after {
+    box-sizing: border-box;
+    /* 1 */
+    border-width: 0;
+    /* 2 */
+    border-style: solid;
+    /* 2 */
+    border-color: currentColor;
+    /* 2 */
+    }
+
+    .constellation::before,
+    .constellation::after {
+    --tw-content: '';
+    }
+
+    /*
+    1. Use a consistent sensible line-height in all browsers.
+    2. Prevent adjustments of font size after orientation changes in iOS.
+    3. Use a more readable tab size.
+    4. Use the user's configured `sans` font-family by default.
+    */
+
+    html .constellation {
+    line-height: 1.5;
+    /* 1 */
+    -webkit-text-size-adjust: 100%;
+    /* 2 */
+    -moz-tab-size: 4;
+    /* 3 */
+    -o-tab-size: 4;
+        tab-size: 4;
+    /* 3 */
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    /* 4 */
+    }
+
+    /*
+    1. Remove the margin in all browsers.
+    2. Inherit line-height from `html` so users can set them as a class directly on the `html` element.
+    */
+
+    body .constellation {
+    margin: 0;
+    /* 1 */
+    line-height: inherit;
+    /* 2 */
+    }
+
+    /*
+    1. Add the correct height in Firefox.
+    2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
+    3. Ensure horizontal rules are visible by default.
+    */
+
+    .constellation hr {
+    height: 0;
+    /* 1 */
+    color: inherit;
+    /* 2 */
+    border-top-width: 1px;
+    /* 3 */
+    }
+
+    /*
+    Add the correct text decoration in Chrome, Edge, and Safari.
+    */
+
+    .constellation abbr:where([title]) {
+    -webkit-text-decoration: underline dotted;
+            text-decoration: underline dotted;
+    }
+
+    /*
+    Remove the default font size and weight for headings.
+    */
+
+    .constellation h1,
+    .constellation h2,
+    .constellation h3,
+    .constellation h4,
+    .constellation h5,
+    .constellation h6 {
+    font-size: inherit;
+    font-weight: inherit;
+    }
+
+    /*
+    Reset links to optimize for opt-in styling instead of opt-out.
+    */
+
+    .constellation a {
+    color: inherit;
+    text-decoration: inherit;
+    }
+
+    /*
+    Add the correct font weight in Edge and Safari.
+    */
+
+    .constellation b,
+    .constellation strong {
+    font-weight: bolder;
+    }
+
+    /*
+    1. Use the user's configured `mono` font family by default.
+    2. Correct the odd `em` font sizing in all browsers.
+    */
+
+    .constellation code,
+    .constellation kbd,
+    .constellation samp,
+    .constellation pre {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    /* 1 */
+    font-size: 1em;
+    /* 2 */
+    }
+
+    /*
+    Add the correct font size in all browsers.
+    */
+
+    .constellation small {
+    font-size: 80%;
+    }
+
+    /*
+    Prevent `sub` and `sup` elements from affecting the line height in all browsers.
+    */
+
+    .constellation sub,
+    .constellation sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+    }
+
+    .constellation sub {
+    bottom: -0.25em;
+    }
+
+    .constellation sup {
+    top: -0.5em;
+    }
+
+    /*
+    1. Remove text indentation from table contents in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=999088, https://bugs.webkit.org/show_bug.cgi?id=201297)
+    2. Correct table border color inheritance in all Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
+    3. Remove gaps between table borders by default.
+    */
+
+    .constellation table {
+    text-indent: 0;
+    /* 1 */
+    border-color: inherit;
+    /* 2 */
+    border-collapse: collapse;
+    /* 3 */
+    }
+
+    /*
+    1. Change the font styles in all browsers.
+    2. Remove the margin in Firefox and Safari.
+    3. Remove default padding in all browsers.
+    */
+
+    .constellation button,
+    .constellation input,
+    .constellation optgroup,
+    .constellation select,
+    .constellation textarea {
+    font-family: inherit;
+    /* 1 */
+    font-size: 100%;
+    /* 1 */
+    font-weight: inherit;
+    /* 1 */
+    line-height: inherit;
+    /* 1 */
+    color: inherit;
+    /* 1 */
+    margin: 0;
+    /* 2 */
+    padding: 0;
+    /* 3 */
+    }
+
+    /*
+    Remove the inheritance of text transform in Edge and Firefox.
+    */
+
+    .constellation button,
+    .constellation select {
+    text-transform: none;
+    }
+
+    /*
+    1. Correct the inability to style clickable types in iOS and Safari.
+    2. Remove default button styles.
+    */
+
+    .constellation button,
+    .constellation [type='button'],
+    .constellation [type='reset'],
+    .constellation [type='submit'] {
+    -webkit-appearance: button;
+    /* 1 */
+    background-color: transparent;
+    /* 2 */
+    background-image: none;
+    /* 2 */
+    }
+
+    /*
+    Use the modern Firefox focus style for all focusable elements.
+    */
+
+    .constellation:-moz-focusring {
+    outline: auto;
+    }
+
+    /*
+    Remove the additional `:invalid` styles in Firefox. (https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737)
+    */
+
+    .constellation:-moz-ui-invalid {
+    box-shadow: none;
+    }
+
+    /*
+    Add the correct vertical alignment in Chrome and Firefox.
+    */
+
+    .constellation progress {
+    vertical-align: baseline;
+    }
+
+    /*
+    Correct the cursor style of increment and decrement buttons in Safari.
+    */
+
+    .constellation::-webkit-inner-spin-button,
+    .constellation::-webkit-outer-spin-button {
+    height: auto;
+    }
+
+    /*
+    1. Correct the odd appearance in Chrome and Safari.
+    2. Correct the outline style in Safari.
+    */
+
+    .constellation [type='search'] {
+    -webkit-appearance: textfield;
+    /* 1 */
+    outline-offset: -2px;
+    /* 2 */
+    }
+
+    /*
+    Remove the inner padding in Chrome and Safari on macOS.
+    */
+
+    .constellation::-webkit-search-decoration {
+    -webkit-appearance: none;
+    }
+
+    /*
+    1. Correct the inability to style clickable types in iOS and Safari.
+    2. Change font properties to `inherit` in Safari.
+    */
+
+    .constellation::-webkit-file-upload-button {
+    -webkit-appearance: button;
+    /* 1 */
+    font: inherit;
+    /* 2 */
+    }
+
+    /*
+    Add the correct display in Chrome and Safari.
+    */
+
+    .constellation summary {
+    display: list-item;
+    }
+
+    /*
+    Removes the default spacing and border for appropriate elements.
+    */
+
+    .constellation blockquote,
+    .constellation dl,
+    .constellation dd,
+    .constellation h1,
+    .constellation h2,
+    .constellation h3,
+    .constellation h4,
+    .constellation h5,
+    .constellation h6,
+    .constellation hr,
+    .constellation figure,
+    .constellation p,
+    .constellation pre {
+    margin: 0;
+    }
+
+    .constellation fieldset {
+    margin: 0;
+    padding: 0;
+    }
+
+    .constellation legend {
+    padding: 0;
+    }
+
+    .constellation ol,
+    .constellation ul,
+    .constellation menu {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    }
+
+    /*
+    Prevent resizing textareas horizontally by default.
+    */
+
+    .constellation textarea {
+    resize: vertical;
+    }
+
+    /*
+    1. Reset the default placeholder opacity in Firefox. (https://github.com/tailwindlabs/tailwindcss/issues/3300)
+    2. Set the default placeholder color to the user's configured gray 400 color.
+    */
+
+    .constellation input::-moz-placeholder, .constellation textarea::-moz-placeholder {
+    opacity: 1;
+    /* 1 */
+    color: #9ca3af;
+    /* 2 */
+    }
+
+    .constellation input::placeholder,
+    .constellation textarea::placeholder {
+    opacity: 1;
+    /* 1 */
+    color: #9ca3af;
+    /* 2 */
+    }
+
+    /*
+    Set the default cursor for buttons.
+    */
+
+    .constellation button,
+    .constellation [role="button"] {
+    cursor: pointer;
+    }
+
+    /*
+    Make sure disabled buttons don't get the pointer cursor.
+    */
+
+    .constellation:disabled {
+    cursor: default;
+    }
+
+    /*
+    1. Make replaced elements `display: block` by default. (https://github.com/mozdevs/cssremedy/issues/14)
+    2. Add `vertical-align: middle` to align replaced elements more sensibly by default. (https://github.com/jensimmons/cssremedy/issues/14#issuecomment-634934210)
+    This can trigger a poorly considered lint error in some tools but is included by design.
+    */
+
+    .constellation img,
+    .constellation svg,
+    .constellation video,
+    .constellation canvas,
+    .constellation audio,
+    .constellation iframe,
+    .constellation embed,
+    .constellation object {
+    display: block;
+    /* 1 */
+    vertical-align: middle;
+    /* 2 */
+    }
+
+    /*
+    Constrain images and videos to the parent width and preserve their intrinsic aspect ratio. (https://github.com/mozdevs/cssremedy/issues/14)
+    */
+
+    .constellation img,
+    .constellation video {
+    max-width: 100%;
+    height: auto;
+    }
+
     :root {
         font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
         font-feature-settings: 'zero' on, 'ss01' on;
@@ -16,13 +428,13 @@
         --color-overlay-dark-600: rgba(3, 17, 47, 0.6);
         --color-overlay-dark-800: rgba(18, 29, 51, 0.8);
 
-        --color-overlay-light-060: rgba(255, 255, 255, 0.06);
-        --color-overlay-light-100: rgba(255, 255, 255, 0.1);
-        --color-overlay-light-200: rgba(255, 255, 255, 0.2);
-        --color-overlay-light-400: rgba(255, 255, 255, 0.4);
-        --color-overlay-light-600: rgba(255, 255, 255, 0.6);
-        --color-overlay-light-800: rgba(255, 255, 255, 0.8);
-        --color-overlay-light-900: #ffffff;
+        --color-overlay-light-060: var(--color-white-060);
+        --color-overlay-light-100: var(--color-white-100);
+        --color-overlay-light-200: var(--color-white-200);
+        --color-overlay-light-400: var(--color-white-400);
+        --color-overlay-light-600: var(--color-white-600);
+        --color-overlay-light-800: var(--color-white-800);
+        --color-overlay-light-900: var(--color-white);
 
         /* Blue */
         --color-blue-000: #ECF5FE;
@@ -122,12 +534,18 @@
 
         /* White */
         --color-white: #FFFFFF;
+        --color-white-000: #FFFFFF;
         --color-white-060: rgba(255, 255, 255, 0.06);
         --color-white-100: rgba(255, 255, 255, 0.1);
         --color-white-200: rgba(255, 255, 255, 0.2);
         --color-white-400: rgba(255, 255, 255, 0.4);
         --color-white-600: rgba(255, 255, 255, 0.6);
         --color-white-800: rgba(255, 255, 255, 0.8);
+
+        /* Black */
+        --color-black: #000000;
+        --color-white: #FFFFFF;
+        --color-transparent: transparent;
 
         /* Tiers */
         --color-tier-silver: #C2C9D6;

--- a/packages/constellation/tailwind.config.js
+++ b/packages/constellation/tailwind.config.js
@@ -153,6 +153,15 @@ module.exports = {
         800: 'var(--color-dark-800)',
         900: 'var(--color-dark-900)',
       },
+      white: {
+        '000': '#FFFFFF',
+        '060': 'rgba(255, 255, 255, 0.06)',
+        100: 'rgba(255, 255, 255, 0.1)',
+        200: 'rgba(255, 255, 255, 0.2)',
+        400: 'rgba(255, 255, 255, 0.4)',
+        600: 'rgba(255, 255, 255, 0.6)',
+        800: 'rgba(255, 255, 255, 0.8)',
+      },
       tiers: {
         silver: 'var(--color-tiers-silver)',
         gold: 'var(--color-tiers-gold)',

--- a/packages/constellation/tailwind.config.js
+++ b/packages/constellation/tailwind.config.js
@@ -166,6 +166,7 @@ module.exports = {
         silver: 'var(--color-tiers-silver)',
         gold: 'var(--color-tiers-gold)',
       },
+      transparent: 'transparent',
     },
     extend: {
       dropShadow: {


### PR DESCRIPTION
This PR adds the first set of button components, which include:
- primary, secondary, and minimal variants
- default, large, and small sizes
- initial, loading, and success states
- disabled states
- light and dark mode support

https://user-images.githubusercontent.com/12600902/179058546-fd578f1f-8a0a-439d-aa7d-52ce20f7c5da.mov

