### PR TITLE
Add Safer TW preflight

### DIFF
--- a/packages/constellation/postcss.config.js
+++ b/packages/constellation/postcss.config.js
@@ -7,7 +7,9 @@ module.exports = {
     autoprefixer: {},
     'postcss-prefix-selector': {
       transform: (prefix, selector) => {
-        if (selector.startsWith('.constellation')) {
+        if (selector.includes('.mode-')) {
+          return selector.replace('.constellation ', '').replace(' .', ' .constellation .')
+        } else if (selector.startsWith('.constellation')) {
           return `${selector}, \n .constellation${selector.replace('.constellation ', '')}`
         }
 

--- a/packages/constellation/postcss.config.js
+++ b/packages/constellation/postcss.config.js
@@ -7,10 +7,12 @@ module.exports = {
     autoprefixer: {},
     'postcss-prefix-selector': {
       transform: (prefix, selector) => {
-        if (selector.includes('.mode-')) {
-          return selector.replace('.constellation ', '').replace(' .', ' .constellation .')
+        if (selector.startsWith('.constellation .mode-')) {
+          const selectorParts = selector.split(' ')
+
+          return `${selectorParts[1]} ${selectorParts[0]} ${selectorParts[2]},\n${selectorParts[1]} ${selectorParts[0]}${selectorParts[2]}`
         } else if (selector.startsWith('.constellation')) {
-          return `${selector}, \n .constellation${selector.replace('.constellation ', '')}`
+          return `${selector},\n.constellation${selector.replace('.constellation ', '')}`
         }
 
         return selector

--- a/packages/constellation/src/components/Base/Loaders/SpinningLoader/SpinningLoader.tsx
+++ b/packages/constellation/src/components/Base/Loaders/SpinningLoader/SpinningLoader.tsx
@@ -37,7 +37,7 @@ const SpinningLoader: SpinningLoaderComponent = ({
         sizeClasses[size],
         variantClasses[variant],
         borderWidthClasses[borderWidth],
-        'constellation relative overflow-hidden rounded-full animate-spin-fast border-solid',
+        'constellation relative overflow-hidden rounded-full animate-spin-fast',
       ])}
     />
   )

--- a/packages/constellation/src/input.css
+++ b/packages/constellation/src/input.css
@@ -3,6 +3,418 @@
 @tailwind utilities;
 
 @layer base {
+    /*
+    ! tailwindcss v3.1.4 | MIT License | https://tailwindcss.com
+    */
+
+    /*
+    1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
+    2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
+    */
+
+    * .constellation,
+    .constellation::before,
+    .constellation::after {
+    box-sizing: border-box;
+    /* 1 */
+    border-width: 0;
+    /* 2 */
+    border-style: solid;
+    /* 2 */
+    border-color: currentColor;
+    /* 2 */
+    }
+
+    .constellation::before,
+    .constellation::after {
+    --tw-content: '';
+    }
+
+    /*
+    1. Use a consistent sensible line-height in all browsers.
+    2. Prevent adjustments of font size after orientation changes in iOS.
+    3. Use a more readable tab size.
+    4. Use the user's configured `sans` font-family by default.
+    */
+
+    html .constellation {
+    line-height: 1.5;
+    /* 1 */
+    -webkit-text-size-adjust: 100%;
+    /* 2 */
+    -moz-tab-size: 4;
+    /* 3 */
+    -o-tab-size: 4;
+        tab-size: 4;
+    /* 3 */
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    /* 4 */
+    }
+
+    /*
+    1. Remove the margin in all browsers.
+    2. Inherit line-height from `html` so users can set them as a class directly on the `html` element.
+    */
+
+    body .constellation {
+    margin: 0;
+    /* 1 */
+    line-height: inherit;
+    /* 2 */
+    }
+
+    /*
+    1. Add the correct height in Firefox.
+    2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
+    3. Ensure horizontal rules are visible by default.
+    */
+
+    .constellation hr {
+    height: 0;
+    /* 1 */
+    color: inherit;
+    /* 2 */
+    border-top-width: 1px;
+    /* 3 */
+    }
+
+    /*
+    Add the correct text decoration in Chrome, Edge, and Safari.
+    */
+
+    .constellation abbr:where([title]) {
+    -webkit-text-decoration: underline dotted;
+            text-decoration: underline dotted;
+    }
+
+    /*
+    Remove the default font size and weight for headings.
+    */
+
+    .constellation h1,
+    .constellation h2,
+    .constellation h3,
+    .constellation h4,
+    .constellation h5,
+    .constellation h6 {
+    font-size: inherit;
+    font-weight: inherit;
+    }
+
+    /*
+    Reset links to optimize for opt-in styling instead of opt-out.
+    */
+
+    .constellation a {
+    color: inherit;
+    text-decoration: inherit;
+    }
+
+    /*
+    Add the correct font weight in Edge and Safari.
+    */
+
+    .constellation b,
+    .constellation strong {
+    font-weight: bolder;
+    }
+
+    /*
+    1. Use the user's configured `mono` font family by default.
+    2. Correct the odd `em` font sizing in all browsers.
+    */
+
+    .constellation code,
+    .constellation kbd,
+    .constellation samp,
+    .constellation pre {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    /* 1 */
+    font-size: 1em;
+    /* 2 */
+    }
+
+    /*
+    Add the correct font size in all browsers.
+    */
+
+    .constellation small {
+    font-size: 80%;
+    }
+
+    /*
+    Prevent `sub` and `sup` elements from affecting the line height in all browsers.
+    */
+
+    .constellation sub,
+    .constellation sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+    }
+
+    .constellation sub {
+    bottom: -0.25em;
+    }
+
+    .constellation sup {
+    top: -0.5em;
+    }
+
+    /*
+    1. Remove text indentation from table contents in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=999088, https://bugs.webkit.org/show_bug.cgi?id=201297)
+    2. Correct table border color inheritance in all Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
+    3. Remove gaps between table borders by default.
+    */
+
+    .constellation table {
+    text-indent: 0;
+    /* 1 */
+    border-color: inherit;
+    /* 2 */
+    border-collapse: collapse;
+    /* 3 */
+    }
+
+    /*
+    1. Change the font styles in all browsers.
+    2. Remove the margin in Firefox and Safari.
+    3. Remove default padding in all browsers.
+    */
+
+    .constellation button,
+    .constellation input,
+    .constellation optgroup,
+    .constellation select,
+    .constellation textarea {
+    font-family: inherit;
+    /* 1 */
+    font-size: 100%;
+    /* 1 */
+    font-weight: inherit;
+    /* 1 */
+    line-height: inherit;
+    /* 1 */
+    color: inherit;
+    /* 1 */
+    margin: 0;
+    /* 2 */
+    padding: 0;
+    /* 3 */
+    }
+
+    /*
+    Remove the inheritance of text transform in Edge and Firefox.
+    */
+
+    .constellation button,
+    .constellation select {
+    text-transform: none;
+    }
+
+    /*
+    1. Correct the inability to style clickable types in iOS and Safari.
+    2. Remove default button styles.
+    */
+
+    .constellation button,
+    .constellation [type='button'],
+    .constellation [type='reset'],
+    .constellation [type='submit'] {
+    -webkit-appearance: button;
+    /* 1 */
+    background-color: transparent;
+    /* 2 */
+    background-image: none;
+    /* 2 */
+    }
+
+    /*
+    Use the modern Firefox focus style for all focusable elements.
+    */
+
+    .constellation:-moz-focusring {
+    outline: auto;
+    }
+
+    /*
+    Remove the additional `:invalid` styles in Firefox. (https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737)
+    */
+
+    .constellation:-moz-ui-invalid {
+    box-shadow: none;
+    }
+
+    /*
+    Add the correct vertical alignment in Chrome and Firefox.
+    */
+
+    .constellation progress {
+    vertical-align: baseline;
+    }
+
+    /*
+    Correct the cursor style of increment and decrement buttons in Safari.
+    */
+
+    .constellation::-webkit-inner-spin-button,
+    .constellation::-webkit-outer-spin-button {
+    height: auto;
+    }
+
+    /*
+    1. Correct the odd appearance in Chrome and Safari.
+    2. Correct the outline style in Safari.
+    */
+
+    .constellation [type='search'] {
+    -webkit-appearance: textfield;
+    /* 1 */
+    outline-offset: -2px;
+    /* 2 */
+    }
+
+    /*
+    Remove the inner padding in Chrome and Safari on macOS.
+    */
+
+    .constellation::-webkit-search-decoration {
+    -webkit-appearance: none;
+    }
+
+    /*
+    1. Correct the inability to style clickable types in iOS and Safari.
+    2. Change font properties to `inherit` in Safari.
+    */
+
+    .constellation::-webkit-file-upload-button {
+    -webkit-appearance: button;
+    /* 1 */
+    font: inherit;
+    /* 2 */
+    }
+
+    /*
+    Add the correct display in Chrome and Safari.
+    */
+
+    .constellation summary {
+    display: list-item;
+    }
+
+    /*
+    Removes the default spacing and border for appropriate elements.
+    */
+
+    .constellation blockquote,
+    .constellation dl,
+    .constellation dd,
+    .constellation h1,
+    .constellation h2,
+    .constellation h3,
+    .constellation h4,
+    .constellation h5,
+    .constellation h6,
+    .constellation hr,
+    .constellation figure,
+    .constellation p,
+    .constellation pre {
+    margin: 0;
+    }
+
+    .constellation fieldset {
+    margin: 0;
+    padding: 0;
+    }
+
+    .constellation legend {
+    padding: 0;
+    }
+
+    .constellation ol,
+    .constellation ul,
+    .constellation menu {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    }
+
+    /*
+    Prevent resizing textareas horizontally by default.
+    */
+
+    .constellation textarea {
+    resize: vertical;
+    }
+
+    /*
+    1. Reset the default placeholder opacity in Firefox. (https://github.com/tailwindlabs/tailwindcss/issues/3300)
+    2. Set the default placeholder color to the user's configured gray 400 color.
+    */
+
+    .constellation input::-moz-placeholder, .constellation textarea::-moz-placeholder {
+    opacity: 1;
+    /* 1 */
+    color: #9ca3af;
+    /* 2 */
+    }
+
+    .constellation input::placeholder,
+    .constellation textarea::placeholder {
+    opacity: 1;
+    /* 1 */
+    color: #9ca3af;
+    /* 2 */
+    }
+
+    /*
+    Set the default cursor for buttons.
+    */
+
+    .constellation button,
+    .constellation [role="button"] {
+    cursor: pointer;
+    }
+
+    /*
+    Make sure disabled buttons don't get the pointer cursor.
+    */
+
+    .constellation:disabled {
+    cursor: default;
+    }
+
+    /*
+    1. Make replaced elements `display: block` by default. (https://github.com/mozdevs/cssremedy/issues/14)
+    2. Add `vertical-align: middle` to align replaced elements more sensibly by default. (https://github.com/jensimmons/cssremedy/issues/14#issuecomment-634934210)
+    This can trigger a poorly considered lint error in some tools but is included by design.
+    */
+
+    .constellation img,
+    .constellation svg,
+    .constellation video,
+    .constellation canvas,
+    .constellation audio,
+    .constellation iframe,
+    .constellation embed,
+    .constellation object {
+    display: block;
+    /* 1 */
+    vertical-align: middle;
+    /* 2 */
+    }
+
+    /*
+    Constrain images and videos to the parent width and preserve their intrinsic aspect ratio. (https://github.com/mozdevs/cssremedy/issues/14)
+    */
+
+    .constellation img,
+    .constellation video {
+    max-width: 100%;
+    height: auto;
+    }
+
     :root {
         font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
         font-feature-settings: 'zero' on, 'ss01' on;


### PR DESCRIPTION
We previously removed the "preflight" defaults from tailwind as they were global styles that did have the potential to conflict with styles in the consuming app. To stop any further possibility of className collisions or style conflicts we added a `.constellation` selector that is required for all constellation classNames. By adding the same selector to all of the preflight classes they will no longer cause any styling conflicts in the consuming app.