### PR TITLE
Update Icon Size Prop

### DIFF
--- a/packages/constellation/src/components/Base/Icon/Icon.stories.tsx
+++ b/packages/constellation/src/components/Base/Icon/Icon.stories.tsx
@@ -10,19 +10,19 @@ export const Icon = ({ icon = 'IconPlus', ...args }: Props & { icon: keyof typeo
 }
 
 export const AllIcons = () => (
-  <div className='constellation flex flex-wrap items-start gap-4'>
+  <ul className='constellation flex flex-wrap justify-center gap-5 p-1'>
     {Object.keys(Icons).map((name) => {
       const Component = Icons[name as keyof typeof Icons]
 
       return (
-        <div className='flex items-center gap-1 w-40' key={name}>
+        <li className='flex items-center gap-1 w-40 flex-col border border-primary p-2' key={name}>
           {/* TODO: update with colors enum */}
-          <Component color='var(--color-primary)' />
-          <p className='text-xs text-body'>{name}</p>
-        </div>
+          <Component color='var(--color-primary)' size={2} />
+          <p className='text-base text-body'>{name}</p>
+        </li>
       )
     })}
-  </div>
+  </ul>
 )
 
 export default {
@@ -39,9 +39,10 @@ export default {
       options: Object.keys(Icons),
     },
     size: {
-      control: { type: 'number' },
-      defaultValue: 2,
-      description: 'Size of the icon in `rem` units',
+      control: { type: 'radio' },
+      defaultValue: 'small',
+      description: 'Size of the icon. This prop also accepts a number for custom `rem` values.',
+      options: ['small', 'medium', 'large'],
     },
   },
   args: {},

--- a/packages/constellation/src/components/Base/Icon/Icon.tsx
+++ b/packages/constellation/src/components/Base/Icon/Icon.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
 
-import { Props } from './Icon.types'
+import { IconSizes, Props } from './Icon.types'
+
+const sizeMap: Record<IconSizes, number> = {
+  large: 2.25,
+  medium: 1.5,
+  small: 1,
+}
 
 /**
  * Icons are used to represent common actions, such as "Add/Remove",
@@ -13,18 +19,21 @@ import { Props } from './Icon.types'
  */
 export const createIconComponent =
   (Icon: React.ElementType): React.FC<Props> =>
-  ({ color, size = 1, titleId, ...otherProps }) =>
-    (
+  ({ color, size = 'small', titleId, ...otherProps }) => {
+    const remSize = typeof size === 'number' ? `${size}rem` : `${sizeMap[size]}rem`
+
+    return (
       <Icon
         {...{
           color: color ? `${color}` : 'inherit',
         }}
         xmlns='http://www.w3.org/2000/svg'
         fill='currentColor'
-        width={`${size}rem`}
-        height={`${size}rem`}
+        width={remSize}
+        height={remSize}
         aria-labelledby={titleId}
         focusable='false'
         {...otherProps}
       />
     )
+  }

--- a/packages/constellation/src/components/Base/Icon/Icon.types.ts
+++ b/packages/constellation/src/components/Base/Icon/Icon.types.ts
@@ -1,5 +1,6 @@
+export type IconSizes = 'small' | 'medium' | 'large'
 export interface Props extends Omit<React.HTMLProps<SVGElement>, 'size'> {
   color?: string // TODO: color enum
-  size?: number
+  size?: IconSizes | number
   titleId?: string
 }


### PR DESCRIPTION
This PR updates the icon size prop to accept either preset `small`/`medium`/`large` values or a number for custom `rem` values. It also makes the icon gallery slightly larger.

https://user-images.githubusercontent.com/12600902/179086293-cae9a454-647e-4ddf-a072-fb2d17ad53ce.mov

