### PR TITLE
Add ThemeProvider Entry to Storybook

### DIFF
--- a/packages/constellation/.storybook/preview.tsx
+++ b/packages/constellation/.storybook/preview.tsx
@@ -24,7 +24,7 @@ const withDisplayGlobals = withGlobals((Story, globalValues) => {
   const darkMode = useDarkMode()
 
   return (
-    <ThemeProvider darkMode={darkMode} theme={globalValues.theme}>
+    <ThemeProvider colorMode={darkMode ? 'dark' : 'light'} theme={globalValues.theme}>
       <Story />
     </ThemeProvider>
   )

--- a/packages/constellation/src/components/ThemeProvider/ThemeProvider.stories.mdx
+++ b/packages/constellation/src/components/ThemeProvider/ThemeProvider.stories.mdx
@@ -1,0 +1,62 @@
+import { Meta } from '@storybook/addon-docs'
+
+<Meta title='Base/ThemeProvider/Intro' />
+
+# ThemeProvider
+
+The `ThemeProvider` is a required component that provides styling and theming to components imported from the Constellation UI Component Library.
+
+## Usage
+
+Set up the `ThemeProvider` component importing it and wrapping the root of your App:
+
+```tsx
+import * as React from 'react'
+
+// 1. import `ThemeProvider` component
+import { ThemeProvider } from '@blockchain-com/constellation'
+
+function App() {
+  // 2. Wrap ThemeProvider at the root of your app
+  return (
+    <ThemeProvider colorMode={true} theme={theme}>
+      <App />
+    </ThemeProvider>
+  )
+}
+```
+
+## Customizing Theme
+
+The theme can be customized by passing in an object containing color overrides:
+
+```tsx
+  ...
+  const customTheme: Theme = { primary: '#e33b94' }
+
+  return (
+    <ThemeProvider colorMode={true} theme={customTheme}>
+      <App />
+    </ThemeProvider>
+  )
+}
+```
+
+[See all colors that can be overridden](?path=/story/base-colors--primary&globals=backgrounds.grid:false)
+
+## Color Mode
+
+The color mode is determined by the consuming app and passed to the `colorMode` prop as a boolean:
+
+```tsx
+  ...
+  // 1. Consuming app determines the color mode
+  const colorMode = useColorMode();
+
+ // 2. Color mode is passed to the colorMode prop
+  <ThemeProvider colorMode={colorMode} theme={}>
+    <App />
+  </ThemeProvider>
+  )
+}
+```

--- a/packages/constellation/src/components/ThemeProvider/ThemeProvider.stories.mdx
+++ b/packages/constellation/src/components/ThemeProvider/ThemeProvider.stories.mdx
@@ -46,7 +46,7 @@ The theme can be customized by passing in an object containing color overrides:
 
 ## Color Mode
 
-The color mode is determined by the consuming app and passed to the `colorMode` prop as a boolean:
+The color mode is determined by the consuming app and passed to the `colorMode` prop:
 
 ```tsx
   ...

--- a/packages/constellation/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/constellation/src/components/ThemeProvider/ThemeProvider.tsx
@@ -5,10 +5,10 @@ import React, { useEffect } from 'react'
 
 import { ThemeProviderComponent } from './ThemeProvider.types'
 
-const ThemeProvider: ThemeProviderComponent = ({ children, darkMode = false, theme = {} }) => {
+const ThemeProvider: ThemeProviderComponent = ({ children, colorMode = 'light', theme = {} }) => {
   useEffect(() => {
-    document.body.classList.add(darkMode ? 'mode-dark' : 'mode-light')
-    document.body.classList.remove(darkMode ? 'mode-light' : 'mode-dark')
+    document.body.classList.add(`mode-${colorMode}`)
+    document.body.classList.remove(colorMode === 'dark' ? 'mode-light' : 'mode-dark')
 
     const themeStyles = Object.keys(theme).reduce(
       (newTheme, color) => `${newTheme} --color-${color}: ${theme[color as keyof typeof theme]};`,
@@ -16,7 +16,7 @@ const ThemeProvider: ThemeProviderComponent = ({ children, darkMode = false, the
     )
 
     document.body.style.cssText = themeStyles
-  }, [theme, darkMode])
+  }, [theme, colorMode])
 
   return <>{children}</>
 }

--- a/packages/constellation/src/components/ThemeProvider/ThemeProvider.types.ts
+++ b/packages/constellation/src/components/ThemeProvider/ThemeProvider.types.ts
@@ -2,7 +2,7 @@ import { FC } from 'react'
 
 interface ThemeProviderProps {
   children: React.ReactNode
-  darkMode: boolean
+  colorMode: 'light' | 'dark'
   theme?: object
 }
 


### PR DESCRIPTION
This PR adds a Storybook entry for ThemeProvider:

<img width="1024" alt="Screen Shot 2022-07-14 at 3 10 35 PM" src="https://user-images.githubusercontent.com/12600902/179097138-0ca44d45-a2cc-4435-9822-b53501e43219.png">
 