### PR TITLE
Add Icon Button Component

### DIFF
--- a/packages/constellation/src/components/Compositions/Buttons/Alert/Alert.tsx
+++ b/packages/constellation/src/components/Compositions/Buttons/Alert/Alert.tsx
@@ -5,7 +5,7 @@ import { Button } from '../Button'
 import { Component as ComponentType, Props } from './Alert.types'
 
 /**
- * Alert Buttons extend of off the Button component, and provide a consistent way
+ * Alert Buttons extend off of the Button component, and provide a consistent way
  * to alert users while giving them an appropriate action to take
  *
  * When a `ref` prop is provided, it will be forwarded to the root element. Any

--- a/packages/constellation/src/components/Compositions/Buttons/Alert/Alert.tsx
+++ b/packages/constellation/src/components/Compositions/Buttons/Alert/Alert.tsx
@@ -1,4 +1,3 @@
-import cx from 'classnames'
 import React, { forwardRef } from 'react'
 
 import { IconAlert } from '../../../Base'
@@ -19,9 +18,7 @@ const AlertButton: ComponentType = forwardRef(
   <T extends React.ElementType = 'button'>(props: Props<T>, ref?: PolymorphicRef<T>) => {
     return (
       <Button
-        className={cx(
-          'constellation rounded-full bg-grey-900 active:bg-grey-900 focus:bg-grey-900 hover:bg-grey-700 disabled:bg-grey-500',
-        )}
+        className='constellation rounded-full bg-grey-900 active:bg-grey-900 focus:bg-grey-900 hover:bg-grey-700 disabled:bg-grey-500'
         ref={ref}
         icon={
           <IconAlert color={props.disabled ? 'var(--color-orange-300)' : 'var(--color-warning)'} />

--- a/packages/constellation/src/components/Compositions/Buttons/Button/Button.tsx
+++ b/packages/constellation/src/components/Compositions/Buttons/Button/Button.tsx
@@ -59,6 +59,7 @@ const Button: ComponentType = forwardRef(
       className,
       disabled = false,
       icon,
+      loaderVariant,
       size = 'default',
       state = 'initial',
       text,
@@ -100,7 +101,7 @@ const Button: ComponentType = forwardRef(
           <SpinningLoader
             size='full'
             borderWidth={size === 'small' ? 'xsmall' : 'small'}
-            variant={variant === 'minimal' ? 'color' : 'monotone'}
+            variant={loaderVariant || variant === 'minimal' ? 'color' : 'monotone'}
           />
         )}
         {state === 'success' && <IconCheck />}

--- a/packages/constellation/src/components/Compositions/Buttons/Button/Button.types.ts
+++ b/packages/constellation/src/components/Compositions/Buttons/Button/Button.types.ts
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { SpinningLoaderProps } from '../../../Base'
+
 export type ButtonVariants = 'primary' | 'secondary' | 'minimal'
 export type ButtonWidths = 'auto' | 'full'
 export type Sizes = 'default' | 'large' | 'small'
@@ -12,6 +14,10 @@ export type Props<T extends React.ElementType> = PolymorphicComponentPropsWithRe
      * An optional Icon displayed inline with button text
      */
     icon?: React.ReactNode
+    /**
+     * Optional override for the button's inline loader stylistic variant
+     */
+    loaderVariant?: SpinningLoaderProps['variant']
     /**
      * The size of the button, from a range of variants.
      */

--- a/packages/constellation/src/components/Compositions/Buttons/IconButton/IconButton.stories.tsx
+++ b/packages/constellation/src/components/Compositions/Buttons/IconButton/IconButton.stories.tsx
@@ -1,0 +1,44 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import React from 'react'
+
+import * as Icons from '../../../Base'
+import { IconButton as IconButtonComponent, IconButtonComponentType } from '.'
+
+export default {
+  argTypes: {
+    as: {
+      control: { type: 'select' },
+      defaultValue: 'button',
+      description: 'Allows for overriding the underlying DOM element ',
+      options: ['button', 'div', 'a'],
+    },
+    disabled: { control: { type: 'boolean' }, defaultValue: false },
+    icon: {
+      control: { type: 'select' },
+      defaultValue: 'IconApple',
+      options: Object.keys(Icons),
+    },
+    onClick: { action: 'click' },
+    size: {
+      control: { type: 'radio' },
+      defaultValue: 'large',
+      options: ['default', 'large', 'small'],
+    },
+    state: {
+      control: { type: 'radio' },
+      defaultValue: 'initial',
+      description: 'An optional visual progress indication of a tiggered button action',
+      options: ['initial', 'loading', 'success'],
+    },
+  },
+  component: IconButtonComponent,
+  title: 'Primitives/Buttons/IconButton',
+} as ComponentMeta<IconButtonComponentType>
+
+const Template: ComponentStory<IconButtonComponentType> = ({ icon, size = 'default', ...args }) => {
+  const StoryIcon = Icons[icon as keyof typeof Icons] as React.FC
+
+  return <IconButtonComponent icon={<StoryIcon />} {...args} size={size} />
+}
+
+export const IconButton = Template.bind({})

--- a/packages/constellation/src/components/Compositions/Buttons/IconButton/IconButton.tsx
+++ b/packages/constellation/src/components/Compositions/Buttons/IconButton/IconButton.tsx
@@ -1,0 +1,43 @@
+import cx from 'classnames'
+import React, { forwardRef } from 'react'
+
+import { Button } from '../Button'
+import { Component as ComponentType, Props, Sizes } from './IconButton.types'
+
+/**
+ * Icon Buttons extend of off the Button component, and enable a button-like click interaction
+ * while maintaining the visual aspects of a provided Icon.
+ *
+ * When a `ref` prop is provided, it will be forwarded to the root element. Any
+ * other properties supplied will be provided to the root element (ie, the `as`
+ * prop value). This includes all appropriate HTML attributes or aria tags. This
+ * component may have its underlying DOM customized via the 'as' prop.
+ */
+
+const sizeClasses: Record<Sizes, string> = {
+  default: 'px-3 py-3',
+  large: 'px-4 py-4',
+  small: 'px-2 py-2',
+}
+
+const IconButton: ComponentType = forwardRef(
+  <T extends React.ElementType = 'button'>(
+    { size, ...otherProps }: Props<T>,
+    ref?: PolymorphicRef<T>,
+  ) => {
+    return (
+      <Button
+        className={cx(
+          'constellation p- bg-transparent hover:bg-transparent focus:bg-transparent disabled:bg-transparent active:bg-transparent text-primary hover:text-blue-700 mode-dark:hover:text-blue-300 active:text-blue-900 mode-dark:active:text-blue-200 focus:text-blue-800 mode-dark:focus:text-blue-200 disabled:text-blue-200 mode-dark:disabled:text-blue-500',
+          sizeClasses[size],
+        )}
+        ref={ref}
+        text=''
+        loaderVariant='color'
+        {...otherProps}
+      />
+    )
+  },
+)
+
+export default IconButton

--- a/packages/constellation/src/components/Compositions/Buttons/IconButton/IconButton.tsx
+++ b/packages/constellation/src/components/Compositions/Buttons/IconButton/IconButton.tsx
@@ -5,7 +5,7 @@ import { Button } from '../Button'
 import { Component as ComponentType, Props, Sizes } from './IconButton.types'
 
 /**
- * Icon Buttons extend of off the Button component, and enable a button-like click interaction
+ * Icon Buttons extend off of the Button component, and enable a button-like click interaction
  * while maintaining the visual aspects of a provided Icon.
  *
  * When a `ref` prop is provided, it will be forwarded to the root element. Any

--- a/packages/constellation/src/components/Compositions/Buttons/IconButton/IconButton.types.ts
+++ b/packages/constellation/src/components/Compositions/Buttons/IconButton/IconButton.types.ts
@@ -1,0 +1,28 @@
+import React from 'react'
+
+export type IconButtonVariants = 'primary' | 'secondary' | 'minimal'
+export type IconButtonWidths = 'auto' | 'full'
+export type Sizes = 'default' | 'large' | 'small'
+export type ButtonState = 'initial' | 'loading' | 'success'
+
+export type Props<T extends React.ElementType> = PolymorphicComponentPropsWithRef<
+  T,
+  {
+    /**
+     * The Icon to be displayed as a clickable button
+     */
+    icon: React.ReactNode
+    /**
+     * The size of the button, from a range of variants.
+     */
+    size: Sizes
+    /**
+     * An optional visual progress indication of a tiggered button action
+     */
+    state?: ButtonState
+  }
+>
+
+export type Component = <T extends React.ElementType = 'button'>(
+  props: Props<T>,
+) => React.ReactElement | null

--- a/packages/constellation/src/components/Compositions/Buttons/IconButton/index.ts
+++ b/packages/constellation/src/components/Compositions/Buttons/IconButton/index.ts
@@ -1,0 +1,5 @@
+export { default as IconButton } from './IconButton'
+export type {
+  Component as IconButtonComponentType,
+  Props as IconButtonProps,
+} from './IconButton.types'

--- a/packages/constellation/src/components/Compositions/Buttons/index.ts
+++ b/packages/constellation/src/components/Compositions/Buttons/index.ts
@@ -1,3 +1,4 @@
 export * from './Alert'
 export * from './Button'
+export * from './IconButton'
 export * from './Link'


### PR DESCRIPTION
This PR adds Icon Buttons to the component library.

<img width="1144" alt="Screen Shot 2022-07-18 at 11 41 05 AM" src="https://user-images.githubusercontent.com/12600902/179580290-dbfd1535-48ae-4f35-821c-442fe8e5a1c1.png">
