### PR TITLE
Small Slider Sizing Tweaks

### DIFF
--- a/packages/constellation/src/components/Compositions/Slider/Slider.tsx
+++ b/packages/constellation/src/components/Compositions/Slider/Slider.tsx
@@ -17,7 +17,7 @@ const Slider: SliderComponent = ({ max, min, step = 1, value, ...props }) => {
       <Track className='relative h-[2px] w-full grow rounded-full bg-medium'>
         <Range className='absolute h-full rounded-full bg-primary' />
       </Track>
-      <Thumb className='block h-6 w-6 rounded-full bg-background border border-solid border-background-light focus:outline-none drop-shadow-control mode-dark:bg-dark-500' />
+      <Thumb className='block h-6 w-6 rounded-full bg-background border border-solid border-grey-000 mode-dark:border-dark-900 focus:outline-none drop-shadow-control mode-dark:bg-dark-500' />
     </Root>
   )
 }

--- a/packages/constellation/src/components/Compositions/Slider/Slider.tsx
+++ b/packages/constellation/src/components/Compositions/Slider/Slider.tsx
@@ -14,10 +14,10 @@ const Slider: SliderComponent = ({ max, min, step = 1, value, ...props }) => {
       aria-label='value'
       className='constellation relative flex h-5 w-64 touch-none items-center'
     >
-      <Track className='relative h-1 w-full grow rounded-full bg-medium'>
+      <Track className='relative h-[2px] w-full grow rounded-full bg-medium'>
         <Range className='absolute h-full rounded-full bg-primary' />
       </Track>
-      <Thumb className='block h-5 w-5 rounded-full bg-background border border-solid border-background-light focus:outline-none drop-shadow-control mode-dark:bg-dark-500' />
+      <Thumb className='block h-6 w-6 rounded-full bg-background border border-solid border-background-light focus:outline-none drop-shadow-control mode-dark:bg-dark-500' />
     </Root>
   )
 }


### PR DESCRIPTION
This PR tweaks the sizing of the Slider thumb and track.

**Before**
<img width="421" alt="Screen Shot 2022-08-03 at 11 37 14 AM" src="https://user-images.githubusercontent.com/12600902/182684361-baccf437-df6f-4bc5-b47d-223e58fe40c7.png">

**After**
<img width="525" alt="Screen Shot 2022-08-03 at 11 42 15 AM" src="https://user-images.githubusercontent.com/12600902/182685146-48c6a3b3-903e-4a0c-8e2e-7e569b3e3461.png">

**Mocks**
<img width="655" alt="Screen Shot 2022-08-03 at 11 38 45 AM" src="https://user-images.githubusercontent.com/12600902/182684588-9924b33f-0ae7-41e2-a6b6-7c72de9cd8a4.png">

