### PR TITLE
Simplify Rollup Config

### DIFF
--- a/packages/constellation/rollup.config.js
+++ b/packages/constellation/rollup.config.js
@@ -11,7 +11,6 @@ import { terser } from 'rollup-plugin-terser'
 import { visualizer } from 'rollup-plugin-visualizer'
 import postcss from 'rollup-plugin-postcss'
 import svgr from '@svgr/rollup'
-import svgo from 'rollup-plugin-svgo'
 
 const packageJson = require('./package.json')
 
@@ -30,58 +29,7 @@ export default (args) => {
       },
       extensions: ['.css'],
     }),
-    svgr({
-      icon: true,
-      titleProp: true,
-      typescript: true,
-    }),
-    svgo({
-      plugins: [
-        {
-          fn: () => {
-            return {
-              element: {
-                enter: (node) => {
-                  if (
-                    node.name === 'svg' &&
-                    node.attributes.width != null &&
-                    node.attributes.height != null
-                  ) {
-                    node.attributes.height = '100%'
-                    node.attributes.width = '100%'
-                  }
-                },
-              },
-            }
-          },
-          name: 'setWidthAndHeight',
-          type: 'visitor',
-        },
-        {
-          fn: () => {
-            return {
-              element: {
-                enter: (node) => {
-                  if (node.name === 'svg') {
-                    node.attributes.fill = 'currentColor'
-                  }
-                },
-              },
-            }
-          },
-          name: 'setCurrentColor',
-          type: 'visitor',
-        },
-        {
-          name: 'preset-default',
-          params: {
-            overrides: {
-              removeViewBox: false,
-            },
-          },
-        },
-      ],
-    }),
+    svgr(),
     commonjs(),
     resolve(),
     typescript({ tsconfig: './tsconfig.json' }),


### PR DESCRIPTION
This PR removes all of the svgr/svgo optimizations in the Rollup config for now so that it matches the Webpack/Storybook config (which seems to handle icons fine) more closely.