### PR TITLE
feat(value-base-cell): add value to basecell props to help with sorting

### DIFF
--- a/packages/constellation/src/components/Compositions/Table/Cells/BaseCell/BaseCell.types.ts
+++ b/packages/constellation/src/components/Compositions/Table/Cells/BaseCell/BaseCell.types.ts
@@ -23,6 +23,10 @@ type Props = {
    */
   toggleSort?: (event: unknown) => void | (() => void)
   /**
+   * value is used here to help with the sorting of a certain column
+   */
+  value?: string | number
+  /**
    * The width of the cell, auto fills the available space. Content sets the with of the cell to
    * the width of the content. Defaults to auto.
    */


### PR DESCRIPTION
When creating an advanced table, having the value prop will help with sorting.