### PR TITLE
fix(Link): replace default tag for Link component

### DIFF
--- a/packages/constellation/src/components/Primitives/Buttons/Link/Link.stories.tsx
+++ b/packages/constellation/src/components/Primitives/Buttons/Link/Link.stories.tsx
@@ -29,7 +29,6 @@ export default {
     text: { control: { type: 'text' }, description: 'Text content of link' },
   },
   args: {
-    as: 'a',
     disabled: false,
     icon: true,
     size: 'large',

--- a/packages/constellation/src/components/Primitives/Buttons/Link/Link.tsx
+++ b/packages/constellation/src/components/Primitives/Buttons/Link/Link.tsx
@@ -39,7 +39,7 @@ const stateStyles: Record<LinkState, Record<Sizes, string>> = {
 }
 
 const Link: ComponentType = forwardRef(
-  <T extends React.ElementType = 'link'>(
+  <T extends React.ElementType = 'a'>(
     {
       as,
       disabled = false,
@@ -51,7 +51,7 @@ const Link: ComponentType = forwardRef(
     }: Props<T>,
     ref?: PolymorphicRef<T>,
   ) => {
-    const Component = as || 'link'
+    const Component = as || 'a'
 
     return (
       <Component


### PR DESCRIPTION
`link` tag should not be used to render `Link` component by default.