### PR TITLE
Fix (Pager): Make it full width of container

### DIFF
--- a/packages/constellation/src/__snapshots__/storyshots.test.ts.snap
+++ b/packages/constellation/src/__snapshots__/storyshots.test.ts.snap
@@ -4741,7 +4741,7 @@ Array [
 
 exports[`Storyshots Compositions/Pager Pager 1`] = `
 <div
-  className="constellation flex items-center justify-between max-w-[375px]"
+  className="constellation flex items-center justify-between w-full"
 >
   <button
     aria-label="page indicator arrow left"

--- a/packages/constellation/src/components/Compositions/Pager/Pager.tsx
+++ b/packages/constellation/src/components/Compositions/Pager/Pager.tsx
@@ -39,7 +39,7 @@ const Arrow = ({ direction, disabled, onChange, selectedPage }: ArrowProps) => (
 
 const Pager: PagerComponent = ({ onChange, selectedPage = 0, totalPages = 5 }) => {
   return (
-    <div className='constellation flex items-center justify-between max-w-[375px]'>
+    <div className='constellation flex items-center justify-between w-full'>
       <Arrow
         direction='left'
         disabled={selectedPage === 0}


### PR DESCRIPTION
We had max width of 375px which isn't aligned with our designs. I suggest to have it 100% width of it's container. In most of the cases I think it will have a proper container just by design. If not, we always can wrap it with a container of a desired width (as we do with padding for example) or add a property for max width here later.